### PR TITLE
Fix Sparse Modifiers

### DIFF
--- a/src/Schema/Grammar.php
+++ b/src/Schema/Grammar.php
@@ -19,6 +19,13 @@ class Grammar extends MySqlGrammar
 {
     use CompilesKeys, ModifiesColumns;
 
+    public function __construct()
+    {
+        // Before anything kicks off, we need to add the SingleStore modifiers
+        // so that they'll get used while the columns are all compiling.
+        $this->addSingleStoreModifiers();
+    }
+
     /**
      * Create the column definition for a spatial Geography type.
      *
@@ -54,10 +61,6 @@ class Grammar extends MySqlGrammar
      */
     protected function compileCreateTable($blueprint, $command, $connection)
     {
-        // Before anything kicks off, we need to add the SingleStore modifiers
-        // so that they'll get used while the columns are all compiling.
-        $this->addSingleStoreModifiers();
-
         // We want to do as little as possible ourselves, so we rely on the parent
         // to compile everything and then potentially sneak some modifiers in.
         return $this->insertCreateTableModifiers(

--- a/src/Schema/Grammar/ModifiesColumns.php
+++ b/src/Schema/Grammar/ModifiesColumns.php
@@ -19,13 +19,24 @@ trait ModifiesColumns
      * @var string[]
      */
     protected $singleStoreModifiers = [
-        'Sparse', 'Option', 'SeriesTimestamp',
+        'SeriesTimestamp', 'Sparse', 'Option',
     ];
 
     protected function addSingleStoreModifiers()
     {
         if (! $this->singleStoreModifiersAdded) {
-            $this->modifiers = array_merge($this->modifiers, $this->singleStoreModifiers);
+            // We need to insert all of our modifiers before the "after" modifier,
+            // otherwise things like "sparse" will come after "after", which is
+            // invalid SQL. So we find the position of the "after" modifier in
+            // the parent, and then slot our modifiers in before it.
+            $index = array_search('After', $this->modifiers);
+
+            $this->modifiers = array_merge(
+                array_slice($this->modifiers, 0, $index),
+                $this->singleStoreModifiers,
+                array_slice($this->modifiers, $index)
+            );
+
             $this->singleStoreModifiersAdded = true;
         }
     }

--- a/src/Schema/Grammar/ModifiesColumns.php
+++ b/src/Schema/Grammar/ModifiesColumns.php
@@ -19,7 +19,7 @@ trait ModifiesColumns
      * @var string[]
      */
     protected $singleStoreModifiers = [
-        'SeriesTimestamp', 'Sparse', 'Option',
+        'Sparse', 'SeriesTimestamp', 'Option',
     ];
 
     protected function addSingleStoreModifiers()

--- a/tests/Hybrid/CreateTable/SparseModifiersTest.php
+++ b/tests/Hybrid/CreateTable/SparseModifiersTest.php
@@ -5,6 +5,9 @@
 
 namespace SingleStore\Laravel\Tests\Hybrid\CreateTable;
 
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 use SingleStore\Laravel\Schema\Blueprint;
 use SingleStore\Laravel\Tests\BaseTest;
 use SingleStore\Laravel\Tests\Hybrid\HybridTestHelpers;
@@ -42,6 +45,25 @@ class SparseModifiersTest extends BaseTest
         $this->assertCreateStatement(
             $blueprint,
             'create rowstore table `test` (`name` varchar(255) not null) compression = sparse'
+        );
+    }
+
+    /** @test */
+    public function sparse_with_after()
+    {
+        // See https://github.com/singlestore-labs/singlestoredb-laravel-driver/issues/18
+        $blueprint = new Blueprint('test');
+
+        $blueprint->string('two_factor_secret')
+            ->after('password')
+            ->nullable()
+            ->sparse();
+
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertEquals(
+            'alter table `test` add `two_factor_secret` varchar(255) null sparse after `password`',
+            $statements[0]
         );
     }
 }

--- a/tests/Hybrid/CreateTable/SparseModifiersTest.php
+++ b/tests/Hybrid/CreateTable/SparseModifiersTest.php
@@ -5,9 +5,6 @@
 
 namespace SingleStore\Laravel\Tests\Hybrid\CreateTable;
 
-use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Schema;
 use SingleStore\Laravel\Schema\Blueprint;
 use SingleStore\Laravel\Tests\BaseTest;
 use SingleStore\Laravel\Tests\Hybrid\HybridTestHelpers;

--- a/tests/Hybrid/Json/JsonWhereTest.php
+++ b/tests/Hybrid/Json/JsonWhereTest.php
@@ -111,7 +111,7 @@ class JsonWhereTest extends BaseTest
         $query = DB::table('test')->whereNull('data->value1');
 
         $this->assertEquals(
-        // @TODO check docs
+            // @TODO check docs
             "select * from `test` where (JSON_EXTRACT_JSON(data, 'value1') is null OR json_type(JSON_EXTRACT_JSON(data, 'value1')) = 'NULL')",
             $query->toSql()
         );
@@ -123,7 +123,7 @@ class JsonWhereTest extends BaseTest
         $query = DB::table('test')->whereNotNull('data->value1');
 
         $this->assertEquals(
-        // @TODO check docs
+            // @TODO check docs
             "select * from `test` where (JSON_EXTRACT_JSON(data, 'value1') is not null AND json_type(JSON_EXTRACT_JSON(data, 'value1')) != 'NULL')",
             $query->toSql()
         );


### PR DESCRIPTION
This fixes #18. 

There were two issues that I found. The first was that the modifiers were only being merged into the grammar on create statements. Now we merge it in the constructor.

The second issue is that the modifiers were merged naively instead of slotting them in in order. Now that we put them in order, it generates valid DDL statements.