### PR TITLE
Implement with statement for sortKey

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,22 @@ Schema::create('table', function (Blueprint $table) {
 
 ```
 
+### Sort Keys - Columnstore variables
+
+Sometimes you may want to customize your [columstore variables](https://docs.singlestore.com/managed-service/en/create-a-database/physical-database-schema-design/procedures-for-physical-database-schema-design/configuring-the-columnstore-to-work-effectively.html) individually per table. You can do it by appending `with` fluently to the `sortKey` definition.
+
+```php
+Schema::create('table', function (Blueprint $table) {
+    $table->string('name');
+
+    $table->sortKey('name')->with(['columnstore_segment_rows' => 100000]);
+});
+
+Schema::create('table', function (Blueprint $table) {
+    $table->string('name')->sortKey()->with(['columnstore_segment_rows' => 100000]);
+});
+```
+
 ### Series Timestamps
 To denote a column as a series timestamp, use the `seriesTimestamp` column modifier.
 

--- a/src/Schema/Blueprint/InlinesIndexes.php
+++ b/src/Schema/Blueprint/InlinesIndexes.php
@@ -81,7 +81,8 @@ trait InlinesIndexes
     protected function indexCommands()
     {
         return $this->commandsNamed(array_merge(
-            $this->singleStoreIndexes, $this->mysqlIndexes
+            $this->singleStoreIndexes,
+            $this->mysqlIndexes
         ));
     }
 
@@ -116,7 +117,14 @@ trait InlinesIndexes
         foreach ($this->columns as $column) {
             foreach ($this->singleStoreIndexes as $index) {
                 if (isset($column->{$index})) {
-                    $this->{$index}($column->name, ($column->{$index} === true ? null : $column->{$index}));
+                    $command = $this->{$index}($column->name, ($column->{$index} === true ? null : $column->{$index}));
+
+                    // Forward with attributes if sortKey
+                    if ($index === 'sortKey' && isset($column->with)) {
+                        $command->with($column->with);
+                        $column->with = null;
+                    }
+
                     $column->{$index} = false;
                 }
             }

--- a/src/Schema/Grammar/CompilesKeys.php
+++ b/src/Schema/Grammar/CompilesKeys.php
@@ -17,6 +17,15 @@ trait CompilesKeys
 
     public function compileSortKey(Blueprint $blueprint, Fluent $command)
     {
+        if (is_array($command->with)) {
+            $compiled = collect($command->with)->map(
+                fn ($value, $variable) => "{$variable}={$value}"
+            )->join(',');
+
+            return "sort key({$this->columnize($command->columns)}) with ({$compiled})";
+        }
+
+
         return "sort key({$this->columnize($command->columns)})";
     }
 

--- a/src/Schema/Grammar/CompilesKeys.php
+++ b/src/Schema/Grammar/CompilesKeys.php
@@ -18,9 +18,9 @@ trait CompilesKeys
     public function compileSortKey(Blueprint $blueprint, Fluent $command)
     {
         if (is_array($command->with)) {
-            $compiled = collect($command->with)->map(
-                fn ($value, $variable) => "{$variable}={$value}"
-            )->join(',');
+            $compiled = collect($command->with)->map(function ($value, $variable) {
+                return "{$variable}={$value}";
+            })->join(',');
 
             return "sort key({$this->columnize($command->columns)} {$command->direction}) with ({$compiled})";
         }

--- a/tests/Hybrid/CreateTable/SortKeysTest.php
+++ b/tests/Hybrid/CreateTable/SortKeysTest.php
@@ -105,7 +105,7 @@ class SortKeysTest extends BaseTest
 
         $this->assertCreateStatement(
             $blueprint,
-            'create table `test` (`name` varchar(255) not null, sort key(`name`) with (columnstore_segment_rows=100000))'
+            'create table `test` (`name` varchar(255) not null, sort key(`name` asc) with (columnstore_segment_rows=100000))'
         );
     }
 
@@ -118,7 +118,7 @@ class SortKeysTest extends BaseTest
 
         $this->assertCreateStatement(
             $blueprint,
-            'create table `test` (`name` varchar(255) not null, sort key(`name`) with (columnstore_segment_rows=100000))'
+            'create table `test` (`name` varchar(255) not null, sort key(`name` asc) with (columnstore_segment_rows=100000))'
         );
     }
 
@@ -134,7 +134,7 @@ class SortKeysTest extends BaseTest
 
         $this->assertCreateStatement(
             $blueprint,
-            'create table `test` (`name` varchar(255) not null, sort key(`name`) with (columnstore_segment_rows=100000,columnstore_flush_bytes=4194304))'
+            'create table `test` (`name` varchar(255) not null, sort key(`name` asc) with (columnstore_segment_rows=100000,columnstore_flush_bytes=4194304))'
         );
     }
 }

--- a/tests/Hybrid/CreateTable/SortKeysTest.php
+++ b/tests/Hybrid/CreateTable/SortKeysTest.php
@@ -67,4 +67,47 @@ class SortKeysTest extends BaseTest
             'create table `test` (`name` varchar(255) not null, shard key(`name`), sort key(`name`))'
         );
     }
+
+    /** @test */
+    public function it_adds_a_sort_key_with_with_statement()
+    {
+        $blueprint = $this->createTable(function (Blueprint $table) {
+            $table->string('name');
+            $table->sortKey('name')->with(['columnstore_segment_rows' => 100000]);
+        });
+
+        $this->assertCreateStatement(
+            $blueprint,
+            'create table `test` (`name` varchar(255) not null, sort key(`name`) with (columnstore_segment_rows=100000))'
+        );
+    }
+
+    /** @test */
+    public function it_adds_a_sort_key_fluent_with_with_statement()
+    {
+        $blueprint = $this->createTable(function (Blueprint $table) {
+            $table->string('name')->sortKey()->with(['columnstore_segment_rows' => 100000]);
+        });
+
+        $this->assertCreateStatement(
+            $blueprint,
+            'create table `test` (`name` varchar(255) not null, sort key(`name`) with (columnstore_segment_rows=100000))'
+        );
+    }
+
+    /** @test */
+    public function it_adds_a_sort_key_fluent_with_dual_with_statement()
+    {
+        $blueprint = $this->createTable(function (Blueprint $table) {
+            $table->string('name')->sortKey()->with([
+                'columnstore_segment_rows' => 100000,
+                'columnstore_flush_bytes' => 4194304,
+            ]);
+        });
+
+        $this->assertCreateStatement(
+            $blueprint,
+            'create table `test` (`name` varchar(255) not null, sort key(`name`) with (columnstore_segment_rows=100000,columnstore_flush_bytes=4194304))'
+        );
+    }
 }


### PR DESCRIPTION
Implements #23 with the following syntax:

```php
$table->sortKey('name')->with(['columnstore_segment_rows' => 100000]);

$table->string('name')->sortKey()->with(['columnstore_segment_rows' => 100000]);

$table->string('name')->sortKey()->with([
    'columnstore_segment_rows' => 100000,
    'columnstore_flush_bytes' => 4194304,
]);
```

Other syntax and their problems:

1. This kind of syntax is currently not possible due to Fluent API limitations.
```php
$table->sortKey('id')->with('columnstore_segment_rows', 100000);
```

2. This syntax would give unnecessary work to keep the lib up to date/with all variables available.
```php
$table->sortKey('id')->withColumnstoreSegmentRows(100000);
```