### PR TITLE
Add withoutPrimaryKey method for increment columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,20 @@ Schema::create('test', function (Blueprint $table) {
 });
 ```
 
+### Increment Columns without Primary Key
+
+Sometimes you may want to set a custom primary key. However if your table has an int `increment` column,
+Laravel, by default, always sets this column as the primary key. Even if you manually set another one. This behavior can be disabled using the `withoutPrimaryKey` method.
+
+```php
+Schema::create('test', function (Blueprint $table) {
+    $table->id()->withoutPrimaryKey();
+    $table->uuid('uuid');
+    
+    $table->primaryKey(['id',  'uuid']);
+});
+```
+
 ## Testing
 
 Execute the tests using PHPUnit

--- a/tests/Hybrid/CreateTable/IncrementWithoutPrimaryKeyTest.php
+++ b/tests/Hybrid/CreateTable/IncrementWithoutPrimaryKeyTest.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * @author https://github.com/srdante
+ */
+
+namespace SingleStore\Laravel\Tests\Hybrid\CreateTable;
+
+use SingleStore\Laravel\Schema\Blueprint;
+use SingleStore\Laravel\Tests\BaseTest;
+use SingleStore\Laravel\Tests\Hybrid\HybridTestHelpers;
+
+class IncrementWithoutPrimaryKeyTest extends BaseTest
+{
+    use HybridTestHelpers;
+
+    /** @test */
+    public function it_adds_a_big_increments_without_primary_key()
+    {
+        $blueprint = $this->createTable(function (Blueprint $table) {
+            $table->bigIncrements('id')->withoutPrimaryKey();
+        });
+
+        $this->assertCreateStatement(
+            $blueprint,
+            'create table `test` (`id` bigint unsigned not null auto_increment)'
+        );
+    }
+
+    /** @test */
+    public function it_adds_an_id_without_primary_key()
+    {
+        $blueprint = $this->createTable(function (Blueprint $table) {
+            $table->id()->withoutPrimaryKey();
+        });
+
+        $this->assertCreateStatement(
+            $blueprint,
+            'create table `test` (`id` bigint unsigned not null auto_increment)'
+        );
+    }
+}

--- a/tests/Hybrid/CreateTable/IncrementWithoutPrimaryKeyTest.php
+++ b/tests/Hybrid/CreateTable/IncrementWithoutPrimaryKeyTest.php
@@ -18,11 +18,14 @@ class IncrementWithoutPrimaryKeyTest extends BaseTest
     {
         $blueprint = $this->createTable(function (Blueprint $table) {
             $table->bigIncrements('id')->withoutPrimaryKey();
+            $table->uuid('uuid');
+
+            $table->primary(['id', 'uuid']);
         });
 
         $this->assertCreateStatement(
             $blueprint,
-            'create table `test` (`id` bigint unsigned not null auto_increment)'
+            'create table `test` (`id` bigint unsigned not null auto_increment, `uuid` char(36) not null, primary key `test_id_uuid_primary`(`id`, `uuid`))'
         );
     }
 
@@ -31,11 +34,14 @@ class IncrementWithoutPrimaryKeyTest extends BaseTest
     {
         $blueprint = $this->createTable(function (Blueprint $table) {
             $table->id()->withoutPrimaryKey();
+            $table->uuid('uuid');
+
+            $table->primary(['id', 'uuid']);
         });
 
         $this->assertCreateStatement(
             $blueprint,
-            'create table `test` (`id` bigint unsigned not null auto_increment)'
+            'create table `test` (`id` bigint unsigned not null auto_increment, `uuid` char(36) not null, primary key `test_id_uuid_primary`(`id`, `uuid`))'
         );
     }
 }


### PR DESCRIPTION
Fixes #22 implementing the `withoutPrimaryKey` method:

```php
$table->bigIncrements('id')->withoutPrimaryKey();
```