### PR TITLE
Implement Sort Key per-column direction feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,17 @@ Schema::create('table', function (Blueprint $table) {
 });
 ```
 
+You may also define the sort key direction per-column using the following syntax:
+
+```php
+Schema::create('table', function (Blueprint $table) {
+    $table->string('f_name');
+    $table->string('l_name');
+
+    $table->sortKey([['f_name', 'asc'], ['l_name', 'desc']]);
+});
+```
+
 ### Unique Keys
 
 You can add an `unique key` to your tables using the standalone `unique` method, or fluently by appending `unique` to the column definition.

--- a/src/Schema/Blueprint/ModifiesIndexes.php
+++ b/src/Schema/Blueprint/ModifiesIndexes.php
@@ -15,7 +15,7 @@ trait ModifiesIndexes
      */
     public function shardKey($columns)
     {
-        return $this->indexCommand('shardKey', $columns, 'shardKeyName');
+        return $this->indexCommand('shardKey', $columns, 'shardKeyDummyName');
     }
 
     /**
@@ -25,7 +25,7 @@ trait ModifiesIndexes
      */
     public function sortKey($columns, $direction = 'asc')
     {
-        $command = $this->indexCommand('sortKey', $columns, 'sortKeyName');
+        $command = $this->indexCommand('sortKey', $columns, 'sortKeyDummyName');
         $command->direction = $direction;
 
         return $command;

--- a/src/Schema/Blueprint/ModifiesIndexes.php
+++ b/src/Schema/Blueprint/ModifiesIndexes.php
@@ -15,7 +15,7 @@ trait ModifiesIndexes
      */
     public function shardKey($columns)
     {
-        return $this->indexCommand('shardKey', $columns, null);
+        return $this->indexCommand('shardKey', $columns, 'shardKeyName');
     }
 
     /**
@@ -25,7 +25,7 @@ trait ModifiesIndexes
      */
     public function sortKey($columns, $direction = 'asc')
     {
-        $command = $this->indexCommand('sortKey', $columns, null);
+        $command = $this->indexCommand('sortKey', $columns, 'sortKeyName');
         $command->direction = $direction;
 
         return $command;

--- a/src/Schema/Grammar.php
+++ b/src/Schema/Grammar.php
@@ -204,7 +204,7 @@ class Grammar extends MySqlGrammar
 
         return implode(', ', array_map(function ($column) use ($direction) {
             if (is_array($column)) {
-                throw new InvalidArgumentException('You must set the direction for each key column or use the second parameter to set the direction for all key columns');
+                throw new InvalidArgumentException('You must set the direction for each sort key column or use the second parameter to set the direction for all sort key columns');
             }
 
             return $column.' '.$direction;

--- a/src/Schema/Grammar.php
+++ b/src/Schema/Grammar.php
@@ -200,13 +200,13 @@ class Grammar extends MySqlGrammar
             }, $columnNames, $columnDirections));
         }
 
+        if (array_filter($columns, 'is_array') !== []) {
+            throw new InvalidArgumentException('You must set the direction for each sort key column or use the second parameter to set the direction for all sort key columns');
+        }
+
         $wrapped = array_map([$this, 'wrap'], $columns);
 
         return implode(', ', array_map(function ($column) use ($direction) {
-            if (is_array($column)) {
-                throw new InvalidArgumentException('You must set the direction for each sort key column or use the second parameter to set the direction for all sort key columns');
-            }
-
             return $column.' '.$direction;
         }, $wrapped));
     }

--- a/tests/Hybrid/CreateTable/SortKeysTest.php
+++ b/tests/Hybrid/CreateTable/SortKeysTest.php
@@ -116,13 +116,13 @@ class SortKeysTest extends BaseTest
     /** @test */
     public function it_cannot_add_a_dual_sort_key_with_only_one_direction()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $blueprint = $this->createTable(function (Blueprint $table) {
             $table->string('f_name');
             $table->string('l_name');
             $table->sortKey(['f_name', ['l_name', 'desc']]);
         });
-
-        $this->expectException(InvalidArgumentException::class);
 
         $blueprint->toSql($this->getConnection(), $this->getGrammar());
     }
@@ -130,13 +130,13 @@ class SortKeysTest extends BaseTest
     /** @test */
     public function it_cannot_add_a_dual_sort_key_with_only_one_direction_desc()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $blueprint = $this->createTable(function (Blueprint $table) {
             $table->string('f_name');
             $table->string('l_name');
             $table->sortKey(['f_name', ['l_name', 'asc']], 'desc');
         });
-
-        $this->expectException(InvalidArgumentException::class);
 
         $blueprint->toSql($this->getConnection(), $this->getGrammar());
     }

--- a/tests/Hybrid/CreateTable/SortKeysTest.php
+++ b/tests/Hybrid/CreateTable/SortKeysTest.php
@@ -83,6 +83,36 @@ class SortKeysTest extends BaseTest
     }
 
     /** @test */
+    public function it_adds_a_dual_sort_key_with_desc_direction()
+    {
+        $blueprint = $this->createTable(function (Blueprint $table) {
+            $table->string('f_name');
+            $table->string('l_name');
+            $table->sortKey(['f_name', 'l_name'], 'desc');
+        });
+
+        $this->assertCreateStatement(
+            $blueprint,
+            'create table `test` (`f_name` varchar(255) not null, `l_name` varchar(255) not null, sort key(`f_name` desc, `l_name` desc))'
+        );
+    }
+
+    /** @test */
+    public function it_adds_a_dual_sort_key_with_different_directions()
+    {
+        $blueprint = $this->createTable(function (Blueprint $table) {
+            $table->string('f_name');
+            $table->string('l_name');
+            $table->sortKey([['f_name', 'asc'], ['l_name', 'desc']]);
+        });
+
+        $this->assertCreateStatement(
+            $blueprint,
+            'create table `test` (`f_name` varchar(255) not null, `l_name` varchar(255) not null, sort key(`f_name` asc, `l_name` desc))'
+        );
+    }
+
+    /** @test */
     public function shard_and_sort_keys()
     {
         $blueprint = $this->createTable(function (Blueprint $table) {

--- a/tests/Hybrid/CreateTable/SortKeysTest.php
+++ b/tests/Hybrid/CreateTable/SortKeysTest.php
@@ -5,6 +5,7 @@
 
 namespace SingleStore\Laravel\Tests\Hybrid\CreateTable;
 
+use InvalidArgumentException;
 use SingleStore\Laravel\Schema\Blueprint;
 use SingleStore\Laravel\Tests\BaseTest;
 use SingleStore\Laravel\Tests\Hybrid\HybridTestHelpers;
@@ -110,6 +111,34 @@ class SortKeysTest extends BaseTest
             $blueprint,
             'create table `test` (`f_name` varchar(255) not null, `l_name` varchar(255) not null, sort key(`f_name` asc, `l_name` desc))'
         );
+    }
+
+    /** @test */
+    public function it_cannot_add_a_dual_sort_key_with_only_one_direction()
+    {
+        $blueprint = $this->createTable(function (Blueprint $table) {
+            $table->string('f_name');
+            $table->string('l_name');
+            $table->sortKey(['f_name', ['l_name', 'desc']]);
+        });
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $blueprint->toSql($this->getConnection(), $this->getGrammar());
+    }
+
+    /** @test */
+    public function it_cannot_add_a_dual_sort_key_with_only_one_direction_desc()
+    {
+        $blueprint = $this->createTable(function (Blueprint $table) {
+            $table->string('f_name');
+            $table->string('l_name');
+            $table->sortKey(['f_name', ['l_name', 'asc']], 'desc');
+        });
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $blueprint->toSql($this->getConnection(), $this->getGrammar());
     }
 
     /** @test */


### PR DESCRIPTION
This pull request implements the Sort Key per-column direction feature using the following syntax:

```php
$table->sortKey([['f_name', 'asc'], ['l_name', 'desc']]);
```

The developer must use the second argument to set the direction for all columns or set a per-column direction for all columns:

```php
$table->sortKey(['f_name', 'l_name'], 'desc'); // Correct (as before)

$table->sortKey([['f_name', 'asc'], ['l_name', 'desc']]); // Correct (now implemented)

$table->sortKey(['f_name', ['l_name', 'desc']]); // Throw exception

$table->sortKey(['f_name', ['l_name', 'asc']], 'desc'); // Throw exception
```

> Note: A dummy index name was added to the shard key & sort key to support the array column syntax (This prevents Laravel from trying to auto-generate the index name from the column name). It does not impact the schema generation since the driver does not use this name attribute.

@carlsverre Let me know if this was the intended behavior! I didn't understand exactly how it was supposed to be implemented.