### PR TITLE
Add empty Sort Key support

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,16 @@ Schema::create('table', function (Blueprint $table) {
 });
 ```
 
+However, you may want to tune it without setting a column as sort key. You can do that by creating an empty `sortKey` definition:
+
+```php
+Schema::create('table', function (Blueprint $table) {
+    $table->string('name');
+
+    $table->sortKey()->with(['columnstore_segment_rows' => 100000]);
+});
+```
+
 ### Unique Keys
 
 You can add an `unique key` to your tables using the standalone `unique` method, or fluently by appending `unique` to the column definition.

--- a/src/Schema/Blueprint/ModifiesIndexes.php
+++ b/src/Schema/Blueprint/ModifiesIndexes.php
@@ -23,7 +23,7 @@ trait ModifiesIndexes
      * @param $direction
      * @return \Illuminate\Support\Fluent
      */
-    public function sortKey($columns, $direction = 'asc')
+    public function sortKey($columns = null, $direction = 'asc')
     {
         $command = $this->indexCommand('sortKey', $columns, 'sortKeyDummyName');
         $command->direction = $direction;

--- a/tests/Hybrid/CreateTable/SortKeysTest.php
+++ b/tests/Hybrid/CreateTable/SortKeysTest.php
@@ -169,7 +169,7 @@ class SortKeysTest extends BaseTest
     }
 
     /** @test */
-    public function it_adds_a_empty_sort_key_with_with_statement()
+    public function it_adds_an_empty_sort_key_with_with_statement()
     {
         $blueprint = $this->createTable(function (Blueprint $table) {
             $table->string('name');

--- a/tests/Hybrid/CreateTable/SortKeysTest.php
+++ b/tests/Hybrid/CreateTable/SortKeysTest.php
@@ -169,6 +169,20 @@ class SortKeysTest extends BaseTest
     }
 
     /** @test */
+    public function it_adds_a_empty_sort_key_with_with_statement()
+    {
+        $blueprint = $this->createTable(function (Blueprint $table) {
+            $table->string('name');
+            $table->sortKey()->with(['columnstore_segment_rows' => 100000]);
+        });
+
+        $this->assertCreateStatement(
+            $blueprint,
+            'create table `test` (`name` varchar(255) not null, sort key() with (columnstore_segment_rows=100000))'
+        );
+    }
+
+    /** @test */
     public function it_adds_a_sort_key_fluent_with_with_statement()
     {
         $blueprint = $this->createTable(function (Blueprint $table) {


### PR DESCRIPTION
This pull request implements support for empty sort key definition. This kind of feature applies when the developer wants to set custom column store variables without setting a column as a sort key.

**Example:**
```php
Schema::create('table', function (Blueprint $table) {
    $table->string('name');

    $table->sortKey()->with(['columnstore_segment_rows' => 100000]);
});
```

