### PR TITLE
Fixed incorrect generation of union queries

### DIFF
--- a/src/Query/Grammar.php
+++ b/src/Query/Grammar.php
@@ -166,11 +166,53 @@ class Grammar extends MySqlGrammar
             }
 
             if (isset($query->unionOffset)) {
-                $sql .= ' '.$this->compileOffset($query, $query->unionOffset);
+                $sql .= ' '.$this->compileUnionOffset($query, $query->unionOffset);
             }
         }
 
         return ltrim($sql);
     }
 
+    /**
+     * Compile the "offset" portions of the query.
+     *
+     * @param  Builder  $query
+     * @param  $offset
+     * @return string
+     */
+    protected function compileOffset(Builder $query, $offset): string
+    {
+        return $this->compileOffsetWithLimit($offset, $query->limit);
+    }
+
+    /**
+     * Compile the "offset" portions of the final union query.
+     *
+     * @param  Builder  $query
+     * @param $offset
+     * @return string
+     */
+    protected function compileUnionOffset(Builder $query, $offset): string
+    {
+        return $this->compileOffsetWithLimit($offset, $query->unionLimit);
+    }
+
+    /**
+     * Compile the "offset" portions of the query taking into account "limit" portion.
+     *
+     * @param $offset
+     * @param $limit
+     * @return string
+     */
+    private function compileOffsetWithLimit($offset, $limit): string
+    {
+        // OFFSET is not valid without LIMIT
+        // Add a huge LIMIT clause
+        if (! isset($limit)) {
+            // 9223372036854775807 - max 64-bit integer
+            return ' LIMIT 9223372036854775807 OFFSET '.(int) $offset;
+        }
+
+        return ' OFFSET '.(int) $offset;
+    }
 }

--- a/tests/Hybrid/UnionTest.php
+++ b/tests/Hybrid/UnionTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace SingleStore\Laravel\Tests\Hybrid;
+
+use Illuminate\Support\Facades\DB;
+use SingleStore\Laravel\Schema\Blueprint;
+use SingleStore\Laravel\Tests\BaseTest;
+
+class UnionTest extends BaseTest
+{
+    use HybridTestHelpers;
+
+    /** @test */
+    function union() {
+        $this->createTable(function (Blueprint $table) {
+            $table->id();
+        });
+
+        DB::table('test')->insert([
+            ['id' => 1],
+            ['id' => 2],
+            ['id' => 3],
+            ['id' => 4],
+            ['id' => 100],
+        ]);
+
+        $first = DB::table('test')->where('id', '<', 3);
+        $second = DB::table('test')->where('id', '>', 5);
+        $res = $first->union($second)->get();
+
+        $indexes = array_map(function ($value): int {
+            return $value->id;
+        }, $res->toArray());
+        sort($indexes);
+
+        $this->assertEquals([1, 2, 100], $indexes);
+    }
+
+    /** @test */
+    function unionWithOrderByLimitAndOffset() {
+        $this->createTable(function (Blueprint $table) {
+            $table->id();
+        });
+
+        DB::table('test')->insert([
+            ['id' => 1],
+            ['id' => 2],
+            ['id' => 3],
+            ['id' => 4],
+            ['id' => 100],
+        ]);
+
+        $first = DB::table('test')->where('id', '<', 3);
+        $second = DB::table('test')->where('id', '>', 5);
+        $res = $first->union($second)->orderBy('id')->limit(1)->offset(1)->get();
+
+        $indexes = array_map(function ($value): int {
+            return $value->id;
+        }, $res->toArray());
+        sort($indexes);
+
+        $this->assertEquals([2], $indexes);
+    }
+
+}

--- a/tests/Hybrid/UnionTest.php
+++ b/tests/Hybrid/UnionTest.php
@@ -120,8 +120,26 @@ class UnionTest extends BaseTest
 
         $first = DB::table('test')->where('id', '<', 3);
         $second = DB::table('test')->where('id', '>', 5);
-        $res = $first->union($second)->offset(1)->limit(100000)->get();
+        $res = $first->union($second)->offset(1)->get();
 
         $this->assertCount(2, $res);
+    }
+
+    /** @test */
+    function unionWithInnerOffset() {
+        if (! $this->runHybridIntegrations()) {
+            return;
+        }
+
+        $first = DB::table('test')->where('id', '<', 3)->offset(1)->orderBy('id');
+        $second = DB::table('test')->where('id', '>', 5);
+        $res = $first->union($second)->get();
+
+        $indexes = array_map(function ($value): int {
+            return $value->id;
+        }, $res->toArray());
+        sort($indexes);
+
+        $this->assertEquals([2, 100], $indexes);
     }
 }

--- a/tests/Hybrid/UnionTest.php
+++ b/tests/Hybrid/UnionTest.php
@@ -10,23 +10,30 @@ class UnionTest extends BaseTest
 {
     use HybridTestHelpers;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if ($this->runHybridIntegrations()) {
+            $this->createTable(function (Blueprint $table) {
+                $table->id();
+            });
+
+            DB::table('test')->insert([
+                ['id' => 1],
+                ['id' => 2],
+                ['id' => 3],
+                ['id' => 4],
+                ['id' => 100],
+            ]);
+        }
+    }
+
     /** @test */
     function union() {
         if (! $this->runHybridIntegrations()) {
             return;
         }
-
-        $this->createTable(function (Blueprint $table) {
-            $table->id();
-        });
-
-        DB::table('test')->insert([
-            ['id' => 1],
-            ['id' => 2],
-            ['id' => 3],
-            ['id' => 4],
-            ['id' => 100],
-        ]);
 
         $first = DB::table('test')->where('id', '<', 3);
         $second = DB::table('test')->where('id', '>', 5);
@@ -41,22 +48,28 @@ class UnionTest extends BaseTest
     }
 
     /** @test */
-    function unionWithOrderByLimitAndOffset() {
+    function unionAll() {
         if (! $this->runHybridIntegrations()) {
             return;
         }
 
-        $this->createTable(function (Blueprint $table) {
-            $table->id();
-        });
+        $first = DB::table('test')->where('id', '<', 4);
+        $second = DB::table('test')->where('id', '>', 2);
+        $res = $first->unionAll($second)->get();
 
-        DB::table('test')->insert([
-            ['id' => 1],
-            ['id' => 2],
-            ['id' => 3],
-            ['id' => 4],
-            ['id' => 100],
-        ]);
+        $indexes = array_map(function ($value): int {
+            return $value->id;
+        }, $res->toArray());
+        sort($indexes);
+
+        $this->assertEquals([1, 2, 3, 3, 4, 100], $indexes);
+    }
+
+    /** @test */
+    function unionWithOrderByLimitAndOffset() {
+        if (! $this->runHybridIntegrations()) {
+            return;
+        }
 
         $first = DB::table('test')->where('id', '<', 3);
         $second = DB::table('test')->where('id', '>', 5);
@@ -65,9 +78,50 @@ class UnionTest extends BaseTest
         $indexes = array_map(function ($value): int {
             return $value->id;
         }, $res->toArray());
-        sort($indexes);
 
         $this->assertEquals([2], $indexes);
     }
 
+    /** @test */
+    function unionWithOrderBy() {
+        if (! $this->runHybridIntegrations()) {
+            return;
+        }
+
+        $first = DB::table('test')->where('id', '<', 3);
+        $second = DB::table('test')->where('id', '>', 5);
+        $res = $first->union($second)->orderBy('id')->get();
+
+        $indexes = array_map(function ($value): int {
+            return $value->id;
+        }, $res->toArray());
+
+        $this->assertEquals([1, 2, 100], $indexes);
+    }
+
+    /** @test */
+    function unionWithLimit() {
+        if (! $this->runHybridIntegrations()) {
+            return;
+        }
+
+        $first = DB::table('test')->where('id', '<', 3);
+        $second = DB::table('test')->where('id', '>', 5);
+        $res = $first->union($second)->limit(2)->get();
+
+        $this->assertCount(2, $res);
+    }
+
+    /** @test */
+    function unionWithOffset() {
+        if (! $this->runHybridIntegrations()) {
+            return;
+        }
+
+        $first = DB::table('test')->where('id', '<', 3);
+        $second = DB::table('test')->where('id', '>', 5);
+        $res = $first->union($second)->offset(1)->limit(100000)->get();
+
+        $this->assertCount(2, $res);
+    }
 }

--- a/tests/Hybrid/UnionTest.php
+++ b/tests/Hybrid/UnionTest.php
@@ -12,6 +12,10 @@ class UnionTest extends BaseTest
 
     /** @test */
     function union() {
+        if (! $this->runHybridIntegrations()) {
+            return;
+        }
+
         $this->createTable(function (Blueprint $table) {
             $table->id();
         });
@@ -38,6 +42,10 @@ class UnionTest extends BaseTest
 
     /** @test */
     function unionWithOrderByLimitAndOffset() {
+        if (! $this->runHybridIntegrations()) {
+            return;
+        }
+
         $this->createTable(function (Blueprint $table) {
             $table->id();
         });


### PR DESCRIPTION
Changed to add SELECT * FROM before each union part. 
Changed to wrap the query before adding a final order by/limit/offset for union queries. 
This is needed because otherwise these clauses are applied only to the last union subquery.

closes #44