### PR TITLE
add rename table support

### DIFF
--- a/src/Schema/Grammar.php
+++ b/src/Schema/Grammar.php
@@ -223,4 +223,18 @@ class Grammar extends MySqlGrammar
                 : ' auto_increment primary key';
         }
     }
+
+    /**
+     * Compile a rename table command.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
+     * @return string
+     */
+    public function compileRename(Blueprint $blueprint, Fluent $command)
+    {
+        $from = $this->wrapTable($blueprint);
+
+        return "alter table {$from} rename to ".$this->wrapTable($command->to);
+    }
 }

--- a/tests/Hybrid/RenameTableTest.php
+++ b/tests/Hybrid/RenameTableTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace SingleStore\Laravel\Tests\Hybrid;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use SingleStore\Laravel\Schema\Blueprint;
+use SingleStore\Laravel\Tests\BaseTest;
+
+class RenameTableTest extends BaseTest
+{
+    use HybridTestHelpers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if ($this->runHybridIntegrations()) {
+            $this->createTable(function (Blueprint $table) {
+                $table->id();
+            });
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->runHybridIntegrations()) {
+            Schema::dropIfExists('test_renamed');
+        }
+
+        parent::tearDown();
+    }
+
+    /** @test */
+    public function rename_table()
+    {
+        if ($this->runHybridIntegrations()) {
+            $cached = $this->mockDatabaseConnection;
+
+            $this->mockDatabaseConnection = false;
+
+            $this->assertFalse(Schema::hasTable('test_renamed'));
+            Schema::rename('test', 'test_renamed');
+
+            $this->assertTrue(Schema::hasTable('test_renamed'));
+
+            $this->mockDatabaseConnection = $cached;
+        }
+
+        $blueprint = new Blueprint('test');
+        $blueprint->rename('test_renamed');
+
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table `test` rename to `test_renamed`', $statements[0]);
+
+    }
+}


### PR DESCRIPTION
Singlestore doesn't accept the mysql style short rename table, it must be  `ALTER TABLE RENAME TO` as seen in: [Alter table docs](https://docs.singlestore.com/db/v7.8/en/reference/sql-reference/data-definition-language-ddl/alter-table.html)