### PR TITLE
add: compilePrimary function to src/Schema/Grammar.php

### DIFF
--- a/src/Schema/Grammar.php
+++ b/src/Schema/Grammar.php
@@ -26,6 +26,20 @@ class Grammar extends MySqlGrammar
     }
 
     /**
+     * Compile a primary key command.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
+     * @return string
+     */
+    public function compilePrimary(Blueprint $blueprint, Fluent $command)
+    {
+        $command->name(null);
+
+        return $this->compileKey($blueprint, $command, 'primary key');
+    }
+
+    /**
      * Create the column definition for a spatial Geography type.
      *
      * @param  \Illuminate\Support\Fluent  $column


### PR DESCRIPTION
There was a PR that was accepted for [laravel/framework:v9.47.0](https://github.com/laravel/framework/releases/tag/v9.47.0) that breaks primary keys with SingleStore.

[[9.x] Remove index name when adding primary key on MySQL #45515](https://github.com/laravel/framework/pull/45515)

Expected query:
```sql
create rowstore table `cache` (
  `key` text not null,
  `value` text not null,
  `expiration` int not null,
  shard key(`key`),
  primary key (`key`)
) default character set utf8mb4 collate 'utf8mb4_unicode_ci'
```

Actual problematic query:
```sql
create rowstore table `cache` (
  `key` text not null,
  `value` text not null,
  `expiration` int not null,
  shard key(`key`),
  alter table
    `cache`
  add
    primary key (`key`)
) default character set utf8mb4 collate 'utf8mb4_unicode_ci'
```