### PR TITLE
Add connection to grammer

### DIFF
--- a/src/Connect/Connection.php
+++ b/src/Connect/Connection.php
@@ -32,7 +32,11 @@ class Connection extends MySqlConnection
      */
     protected function getDefaultQueryGrammar()
     {
-        return $this->withTablePrefix((new Query\Grammar)->setConnection($this));
+        $grammar = new Query\Grammar;
+        if (method_exists($grammar, 'setConnection')) {
+            $grammar->setConnection($this);
+        }
+        return $this->withTablePrefix($grammar);
     }
 
     /**
@@ -42,7 +46,11 @@ class Connection extends MySqlConnection
      */
     protected function getDefaultSchemaGrammar()
     {
-        return $this->withTablePrefix((new Schema\Grammar)->setConnection($this));
+        $grammar = new Schema\Grammar;
+        if (method_exists($grammar, 'setConnection')) {
+            $grammar->setConnection($this);
+        }
+        return $this->withTablePrefix($grammar);
     }
 
     /**


### PR DESCRIPTION
`Illuminate\Database\Grammer::escape` functionality moved to `Illuminate\Database\Connection::escape` ([commit](https://github.com/laravel/framework/commit/e953137280cdf6e0fe3c3e4c49d7209ad86c92c0)) and it needs `connection` instance to work.
It used in toRawSql, dumpRawSql() and ddRawSql() new methods ([#47507](https://github.com/laravel/framework/pull/47507))