### PR TITLE
Modified generation of the union queries

### DIFF
--- a/src/Query/Grammar.php
+++ b/src/Query/Grammar.php
@@ -179,7 +179,6 @@ class Grammar extends MySqlGrammar
     /**
      * Compile a single union statement.
      *
-     * @param  array  $union
      * @return string
      */
     protected function compileUnion(array $union)

--- a/src/Query/Grammar.php
+++ b/src/Query/Grammar.php
@@ -177,6 +177,19 @@ class Grammar extends MySqlGrammar
     }
 
     /**
+     * Compile a single union statement.
+     *
+     * @param  array  $union
+     * @return string
+     */
+    protected function compileUnion(array $union)
+    {
+        $conjunction = $union['all'] ? ' union all ' : ' union ';
+
+        return $conjunction.'('.$union['query']->toSql().')';
+    }
+
+    /**
      * Compile a select query into SQL.
      *
      * @return string


### PR DESCRIPTION
Previously it generated union queries like 
SELECT * FROM (original query) UNION ALL SELECT * FROM (subquery).
It doesn't work with recursive CTE in S2.
Now connector will generate the following queries.
SELECT * from (original query) UNION ALL (subquery).
