### PR TITLE
Fixed generation of PK

### DIFF
--- a/src/Schema/Blueprint/InlinesIndexes.php
+++ b/src/Schema/Blueprint/InlinesIndexes.php
@@ -122,6 +122,10 @@ trait InlinesIndexes
         $indexStatementKeys = [];
 
         foreach ($this->commands as $command) {
+            if ($command->shouldBeSkipped) {
+                continue;
+            }
+
             $method = 'compile'.ucfirst($command->name);
             $isIndex = $this->isIndexCommand($command);
 

--- a/tests/Hybrid/CreateTable/IncrementWithoutPrimaryKeyTest.php
+++ b/tests/Hybrid/CreateTable/IncrementWithoutPrimaryKeyTest.php
@@ -2,6 +2,7 @@
 
 namespace SingleStore\Laravel\Tests\Hybrid\CreateTable;
 
+use Illuminate\Foundation\Application;
 use SingleStore\Laravel\Schema\Blueprint;
 use SingleStore\Laravel\Tests\BaseTest;
 use SingleStore\Laravel\Tests\Hybrid\HybridTestHelpers;
@@ -20,10 +21,17 @@ class IncrementWithoutPrimaryKeyTest extends BaseTest
             $table->primary(['id', 'uuid']);
         });
 
-        $this->assertCreateStatement(
-            $blueprint,
-            'create table `test` (`id` bigint unsigned not null auto_increment, `uuid` char(36) not null, primary key `test_id_uuid_primary`(`id`, `uuid`))'
-        );
+        if (version_compare(Application::VERSION, '10.38.0', '>=')) {
+            $this->assertCreateStatement(
+                $blueprint,
+                'create table `test` (`id` bigint unsigned not null auto_increment, `uuid` char(36) not null, primary key (`id`, `uuid`))'
+            );
+        } else {
+            $this->assertCreateStatement(
+                $blueprint,
+                'create table `test` (`id` bigint unsigned not null auto_increment, `uuid` char(36) not null, primary key `test_id_uuid_primary`(`id`, `uuid`))'
+            );
+        }
     }
 
     /** @test */
@@ -36,9 +44,16 @@ class IncrementWithoutPrimaryKeyTest extends BaseTest
             $table->primary(['id', 'uuid']);
         });
 
-        $this->assertCreateStatement(
-            $blueprint,
-            'create table `test` (`id` bigint unsigned not null auto_increment, `uuid` char(36) not null, primary key `test_id_uuid_primary`(`id`, `uuid`))'
-        );
+        if (version_compare(Application::VERSION, '10.38.0', '>=')) {
+            $this->assertCreateStatement(
+                $blueprint,
+                'create table `test` (`id` bigint unsigned not null auto_increment, `uuid` char(36) not null, primary key (`id`, `uuid`))'
+            );
+        } else {
+            $this->assertCreateStatement(
+                $blueprint,
+                'create table `test` (`id` bigint unsigned not null auto_increment, `uuid` char(36) not null, primary key `test_id_uuid_primary`(`id`, `uuid`))'
+            );
+        }
     }
 }

--- a/tests/Hybrid/CreateTable/MiscCreateTest.php
+++ b/tests/Hybrid/CreateTable/MiscCreateTest.php
@@ -2,6 +2,7 @@
 
 namespace SingleStore\Laravel\Tests\Hybrid\CreateTable;
 
+use Illuminate\Foundation\Application;
 use SingleStore\Laravel\Schema\Blueprint;
 use SingleStore\Laravel\Tests\BaseTest;
 use SingleStore\Laravel\Tests\Hybrid\HybridTestHelpers;
@@ -20,10 +21,17 @@ class MiscCreateTest extends BaseTest
             $table->index('foo', 'name3', 'hash');
         });
 
-        $this->assertCreateStatement(
-            $blueprint,
-            'create table `test` (`primary` varchar(255) not null, `index` varchar(255) not null, `foo` varchar(255) not null, index `name3` using hash(`foo`), primary key `name1`(`primary`), index `name2`(`index`))'
-        );
+        if (version_compare(Application::VERSION, '10.38.0', '>=')) {
+            $this->assertCreateStatement(
+                $blueprint,
+                'create table `test` (`primary` varchar(255) not null, `index` varchar(255) not null, `foo` varchar(255) not null, index `name3` using hash(`foo`), index `name2`(`index`), primary key (`primary`))'
+            );
+        } else {
+            $this->assertCreateStatement(
+                $blueprint,
+                'create table `test` (`primary` varchar(255) not null, `index` varchar(255) not null, `foo` varchar(255) not null, index `name3` using hash(`foo`), primary key `name1`(`primary`), index `name2`(`index`))'
+            );
+        }
     }
 
     /** @test */
@@ -36,10 +44,17 @@ class MiscCreateTest extends BaseTest
             $table->geography('georegion')->spatialIndex('name3');
         });
 
-        $this->assertCreateStatement(
-            $blueprint,
-            'create rowstore table `test` (`primary` varchar(255) not null, `index` varchar(255) not null, `georegion` geography not null, primary key `name1`(`primary`), index `name2`(`index`), index `name3`(`georegion`))'
-        );
+        if (version_compare(Application::VERSION, '10.38.0', '>=')) {
+            $this->assertCreateStatement(
+                $blueprint,
+                'create rowstore table `test` (`primary` varchar(255) not null, `index` varchar(255) not null, `georegion` geography not null, index `name2`(`index`), index `name3`(`georegion`), primary key (`primary`))'
+            );
+        } else {
+            $this->assertCreateStatement(
+                $blueprint,
+                'create rowstore table `test` (`primary` varchar(255) not null, `index` varchar(255) not null, `georegion` geography not null, primary key `name1`(`primary`), index `name2`(`index`), index `name3`(`georegion`))'
+            );
+        }
     }
 
     /** @test */
@@ -68,10 +83,17 @@ class MiscCreateTest extends BaseTest
             $table->timestamps();
         });
 
-        $this->assertCreateStatement(
-            $blueprint,
-            'create table `test` (`id` bigint unsigned not null auto_increment, `user_id` bigint unsigned not null, `template_id` varchar(255) not null, `data` longtext not null, `response_status_code` varchar(255) not null, `response_message` longtext not null, `created_at` timestamp null, `updated_at` timestamp null, index `test_id_index`(`id`), shard key(`user_id`))'
-        );
+        if (version_compare(Application::VERSION, '10.38.0', '>=')) {
+            $this->assertCreateStatement(
+                $blueprint,
+                'create table `test` (`id` bigint unsigned not null auto_increment, `user_id` bigint unsigned not null, `template_id` varchar(255) not null, `data` longtext not null, `response_status_code` varchar(255) not null, `response_message` longtext not null, `created_at` timestamp null, `updated_at` timestamp null, index `test_id_index`(`id`), shard key(`user_id`))'
+            );
+        } else {
+            $this->assertCreateStatement(
+                $blueprint,
+                'create table `test` (`id` bigint unsigned not null auto_increment, `user_id` bigint unsigned not null, `template_id` varchar(255) not null, `data` longtext not null, `response_status_code` varchar(255) not null, `response_message` longtext not null, `created_at` timestamp null, `updated_at` timestamp null, index `test_id_index`(`id`), shard key(`user_id`))'
+            );
+        }
     }
 
     /** @test */


### PR DESCRIPTION
In the newer version of Laravel PK is added to the CREATE TABLE statement. See https://github.com/laravel/framework/pull/49374/files Our implementation added it from commands and didn't take into account that it is marked as ignored.

Closes #76 