### PR TITLE
Fixed groupLimit functionality

### DIFF
--- a/src/Connect/Connector.php
+++ b/src/Connect/Connector.php
@@ -4,6 +4,4 @@ namespace SingleStore\Laravel\Connect;
 
 use Illuminate\Database\Connectors\MySqlConnector;
 
-class Connector extends MySqlConnector
-{
-}
+class Connector extends MySqlConnector {}

--- a/src/Exceptions/SingleStoreDriverException.php
+++ b/src/Exceptions/SingleStoreDriverException.php
@@ -2,6 +2,4 @@
 
 namespace SingleStore\Laravel\Exceptions;
 
-class SingleStoreDriverException extends \Exception
-{
-}
+class SingleStoreDriverException extends \Exception {}

--- a/src/Exceptions/UnsupportedFunctionException.php
+++ b/src/Exceptions/UnsupportedFunctionException.php
@@ -2,6 +2,4 @@
 
 namespace SingleStore\Laravel\Exceptions;
 
-class UnsupportedFunctionException extends SingleStoreDriverException
-{
-}
+class UnsupportedFunctionException extends SingleStoreDriverException {}

--- a/src/Fluency/SpatialIndexCommand.php
+++ b/src/Fluency/SpatialIndexCommand.php
@@ -7,6 +7,4 @@ use Illuminate\Support\Fluent;
 /**
  * @method $this resolution(int $resolution) The spatial index resolution
  */
-class SpatialIndexCommand extends Fluent
-{
-}
+class SpatialIndexCommand extends Fluent {}

--- a/src/Query/Grammar.php
+++ b/src/Query/Grammar.php
@@ -11,10 +11,10 @@ class Grammar extends MySqlGrammar
     {
         $optionString = '';
         foreach ($options as $key => $value) {
-            if (!empty($optionString)) {
+            if (! empty($optionString)) {
                 $optionString .= ',';
             }
-            $optionString .= $key . '=' . $value;
+            $optionString .= $key.'='.$value;
         }
 
         return "OPTION ({$optionString})";
@@ -81,7 +81,7 @@ class Grammar extends MySqlGrammar
         if ($this->isJsonSelector($where['column'])) {
             [$field, $path] = $this->wrapJsonFieldAndPath($where['column']);
 
-            return '(JSON_EXTRACT_JSON(' . $field . $path . ') IS NULL OR JSON_GET_TYPE(JSON_EXTRACT_JSON(' . $field . $path . ')) = \'NULL\')';
+            return '(JSON_EXTRACT_JSON('.$field.$path.') IS NULL OR JSON_GET_TYPE(JSON_EXTRACT_JSON('.$field.$path.')) = \'NULL\')';
         }
 
         return parent::whereNull($query, $where);
@@ -92,7 +92,7 @@ class Grammar extends MySqlGrammar
         if ($this->isJsonSelector($where['column'])) {
             [$field, $path] = $this->wrapJsonFieldAndPath($where['column']);
 
-            return '(JSON_EXTRACT_JSON(' . $field . $path . ') IS NOT NULL AND JSON_GET_TYPE(JSON_EXTRACT_JSON(' . $field . $path . ')) != \'NULL\')';
+            return '(JSON_EXTRACT_JSON('.$field.$path.') IS NOT NULL AND JSON_GET_TYPE(JSON_EXTRACT_JSON('.$field.$path.')) != \'NULL\')';
         }
 
         return parent::whereNotNull($query, $where);
@@ -103,7 +103,7 @@ class Grammar extends MySqlGrammar
         // Break apart the column name from the JSON keypath.
         [$field, $path] = $this->wrapJsonFieldAndPath($value);
 
-        if (!$path) {
+        if (! $path) {
             return $field;
         }
 
@@ -144,7 +144,7 @@ class Grammar extends MySqlGrammar
             return "'$part'";
         }, $parts);
 
-        $path = count($parts) ? ', ' . implode(', ', $parts) : '';
+        $path = count($parts) ? ', '.implode(', ', $parts) : '';
 
         return [$field, $path];
     }
@@ -157,7 +157,7 @@ class Grammar extends MySqlGrammar
      */
     protected function wrapUnion($sql)
     {
-        return 'SELECT * FROM (' . $sql . ')';
+        return 'SELECT * FROM ('.$sql.')';
     }
 
     /**
@@ -185,7 +185,7 @@ class Grammar extends MySqlGrammar
     {
         $conjunction = $union['all'] ? ' union all ' : ' union ';
 
-        return $conjunction . '(' . $union['query']->toSql() . ')';
+        return $conjunction.'('.$union['query']->toSql().')';
     }
 
     /**
@@ -203,19 +203,19 @@ class Grammar extends MySqlGrammar
             return ltrim($sql);
         }
 
-        if (!empty($query->unionOrders) || isset($query->unionLimit) || isset($query->unionOffset)) {
-            $sql = 'SELECT * FROM (' . $sql . ') ';
+        if (! empty($query->unionOrders) || isset($query->unionLimit) || isset($query->unionOffset)) {
+            $sql = 'SELECT * FROM ('.$sql.') ';
 
-            if (!empty($query->unionOrders)) {
-                $sql .= ' ' . $this->compileOrders($query, $query->unionOrders);
+            if (! empty($query->unionOrders)) {
+                $sql .= ' '.$this->compileOrders($query, $query->unionOrders);
             }
 
             if (isset($query->unionLimit)) {
-                $sql .= ' ' . $this->compileLimit($query, $query->unionLimit);
+                $sql .= ' '.$this->compileLimit($query, $query->unionLimit);
             }
 
             if (isset($query->unionOffset)) {
-                $sql .= ' ' . $this->compileUnionOffset($query, $query->unionOffset);
+                $sql .= ' '.$this->compileUnionOffset($query, $query->unionOffset);
             }
         }
 
@@ -247,12 +247,12 @@ class Grammar extends MySqlGrammar
     {
         // OFFSET is not valid without LIMIT
         // Add a huge LIMIT clause
-        if (!isset($limit)) {
+        if (! isset($limit)) {
             // 9223372036854775807 - max 64-bit integer
-            return ' LIMIT 9223372036854775807 OFFSET ' . (int) $offset;
+            return ' LIMIT 9223372036854775807 OFFSET '.(int) $offset;
         }
 
-        return ' OFFSET ' . (int) $offset;
+        return ' OFFSET '.(int) $offset;
     }
 
     /**

--- a/src/Query/Grammar.php
+++ b/src/Query/Grammar.php
@@ -11,10 +11,10 @@ class Grammar extends MySqlGrammar
     {
         $optionString = '';
         foreach ($options as $key => $value) {
-            if (! empty($optionString)) {
+            if (!empty($optionString)) {
                 $optionString .= ',';
             }
-            $optionString .= $key.'='.$value;
+            $optionString .= $key . '=' . $value;
         }
 
         return "OPTION ({$optionString})";
@@ -81,7 +81,7 @@ class Grammar extends MySqlGrammar
         if ($this->isJsonSelector($where['column'])) {
             [$field, $path] = $this->wrapJsonFieldAndPath($where['column']);
 
-            return '(JSON_EXTRACT_JSON('.$field.$path.') IS NULL OR JSON_GET_TYPE(JSON_EXTRACT_JSON('.$field.$path.')) = \'NULL\')';
+            return '(JSON_EXTRACT_JSON(' . $field . $path . ') IS NULL OR JSON_GET_TYPE(JSON_EXTRACT_JSON(' . $field . $path . ')) = \'NULL\')';
         }
 
         return parent::whereNull($query, $where);
@@ -92,7 +92,7 @@ class Grammar extends MySqlGrammar
         if ($this->isJsonSelector($where['column'])) {
             [$field, $path] = $this->wrapJsonFieldAndPath($where['column']);
 
-            return '(JSON_EXTRACT_JSON('.$field.$path.') IS NOT NULL AND JSON_GET_TYPE(JSON_EXTRACT_JSON('.$field.$path.')) != \'NULL\')';
+            return '(JSON_EXTRACT_JSON(' . $field . $path . ') IS NOT NULL AND JSON_GET_TYPE(JSON_EXTRACT_JSON(' . $field . $path . ')) != \'NULL\')';
         }
 
         return parent::whereNotNull($query, $where);
@@ -103,7 +103,7 @@ class Grammar extends MySqlGrammar
         // Break apart the column name from the JSON keypath.
         [$field, $path] = $this->wrapJsonFieldAndPath($value);
 
-        if (! $path) {
+        if (!$path) {
             return $field;
         }
 
@@ -144,7 +144,7 @@ class Grammar extends MySqlGrammar
             return "'$part'";
         }, $parts);
 
-        $path = count($parts) ? ', '.implode(', ', $parts) : '';
+        $path = count($parts) ? ', ' . implode(', ', $parts) : '';
 
         return [$field, $path];
     }
@@ -157,7 +157,7 @@ class Grammar extends MySqlGrammar
      */
     protected function wrapUnion($sql)
     {
-        return 'SELECT * FROM ('.$sql.')';
+        return 'SELECT * FROM (' . $sql . ')';
     }
 
     /**
@@ -185,7 +185,7 @@ class Grammar extends MySqlGrammar
     {
         $conjunction = $union['all'] ? ' union all ' : ' union ';
 
-        return $conjunction.'('.$union['query']->toSql().')';
+        return $conjunction . '(' . $union['query']->toSql() . ')';
     }
 
     /**
@@ -203,19 +203,19 @@ class Grammar extends MySqlGrammar
             return ltrim($sql);
         }
 
-        if (! empty($query->unionOrders) || isset($query->unionLimit) || isset($query->unionOffset)) {
-            $sql = 'SELECT * FROM ('.$sql.') ';
+        if (!empty($query->unionOrders) || isset($query->unionLimit) || isset($query->unionOffset)) {
+            $sql = 'SELECT * FROM (' . $sql . ') ';
 
-            if (! empty($query->unionOrders)) {
-                $sql .= ' '.$this->compileOrders($query, $query->unionOrders);
+            if (!empty($query->unionOrders)) {
+                $sql .= ' ' . $this->compileOrders($query, $query->unionOrders);
             }
 
             if (isset($query->unionLimit)) {
-                $sql .= ' '.$this->compileLimit($query, $query->unionLimit);
+                $sql .= ' ' . $this->compileLimit($query, $query->unionLimit);
             }
 
             if (isset($query->unionOffset)) {
-                $sql .= ' '.$this->compileUnionOffset($query, $query->unionOffset);
+                $sql .= ' ' . $this->compileUnionOffset($query, $query->unionOffset);
             }
         }
 
@@ -247,12 +247,12 @@ class Grammar extends MySqlGrammar
     {
         // OFFSET is not valid without LIMIT
         // Add a huge LIMIT clause
-        if (! isset($limit)) {
+        if (!isset($limit)) {
             // 9223372036854775807 - max 64-bit integer
-            return ' LIMIT 9223372036854775807 OFFSET '.(int) $offset;
+            return ' LIMIT 9223372036854775807 OFFSET ' . (int) $offset;
         }
 
-        return ' OFFSET '.(int) $offset;
+        return ' OFFSET ' . (int) $offset;
     }
 
     /**
@@ -270,5 +270,10 @@ class Grammar extends MySqlGrammar
         $deleteTable = last(explode('.', $table));
 
         return "delete {$deleteTable} from {$table} {$joins} {$where}";
+    }
+
+    public function useLegacyGroupLimit(Builder $query)
+    {
+        return false;
     }
 }

--- a/tests/Hybrid/GroupLimitTest.php
+++ b/tests/Hybrid/GroupLimitTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace SingleStore\Laravel\Tests\Hybrid;
+
+use Illuminate\Foundation\Application;
+use SingleStore\Laravel\Tests\BaseTest;
+use Illuminate\Support\Facades\DB;
+use SingleStore\Laravel\Schema\Blueprint;
+use SingleStore\Laravel\Tests\Hybrid\HybridTestHelpers;
+
+class GroupLimitTest extends BaseTest
+{
+    use HybridTestHelpers;
+
+    /** @test */
+    public function groupLimit()
+    {
+        if (version_compare(Application::VERSION, '11.0.0', '<')) {
+            // fulltext not added until later on in laravel 8 releases
+            $this->markTestSkipped('requires higher laravel version');
+
+            return;
+        }
+
+        $query = DB::table('test')->orderBy('id')->groupLimit(2, 'group');
+        $this->assertEquals(
+            'select * from (select *, row_number() over (partition by `group` order by `id` asc) as `laravel_row` from `test`) as `laravel_table` where `laravel_row` <= 2 order by `laravel_row`',
+            $query->toSql()
+        );
+
+        if (!$this->runHybridIntegrations()) {
+            return;
+        }
+
+        $this->createTable(function (Blueprint $table) {
+            $table->id();
+            $table->integer('group');
+        });
+
+        DB::table('test')->insert([
+            ['id' => 1, 'group' => 1],
+            ['id' => 2, 'group' => 1],
+            ['id' => 3, 'group' => 1],
+            ['id' => 4, 'group' => 2],
+            ['id' => 5, 'group' => 3],
+            ['id' => 6, 'group' => 3],
+            ['id' => 7, 'group' => 3],
+            ['id' => 8, 'group' => 3],
+        ]);
+
+        $ids = $query->get(['id'])->pluck('id')->toArray();
+        sort($ids);
+        $this->assertEquals($ids, [1, 2, 4, 5, 6]);
+    }
+}

--- a/tests/Hybrid/GroupLimitTest.php
+++ b/tests/Hybrid/GroupLimitTest.php
@@ -3,10 +3,9 @@
 namespace SingleStore\Laravel\Tests\Hybrid;
 
 use Illuminate\Foundation\Application;
-use SingleStore\Laravel\Tests\BaseTest;
 use Illuminate\Support\Facades\DB;
 use SingleStore\Laravel\Schema\Blueprint;
-use SingleStore\Laravel\Tests\Hybrid\HybridTestHelpers;
+use SingleStore\Laravel\Tests\BaseTest;
 
 class GroupLimitTest extends BaseTest
 {
@@ -28,7 +27,7 @@ class GroupLimitTest extends BaseTest
             $query->toSql()
         );
 
-        if (!$this->runHybridIntegrations()) {
+        if (! $this->runHybridIntegrations()) {
             return;
         }
 


### PR DESCRIPTION
This functionality was added in Laravel 11.
MySQL driver checks the version of the database and if it is less than 8 then generates a query with unsupported syntax for UDV.
It seems that functionality for MySQL >= 8 works well with SingleStore. 
Added test that checks this.