### PR TITLE
Fix column modifying on columnstore tables

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,10 +25,10 @@
   ],
   "require": {
     "php": "^7.3|^8.0",
-    "illuminate/container": "^8.0|^9.0|^10.0|^11.0",
-    "illuminate/database": "^8.0|^9.0|^10.0|^11.0",
-    "illuminate/events": "^8.0|^9.0|^10.0|^11.0",
-    "illuminate/support": "^8.0|^9.0|^10.0|^11.0"
+    "illuminate/container": "^8.0|^9.0|^10.0|^11.15",
+    "illuminate/database": "^8.0|^9.0|^10.0|^11.15",
+    "illuminate/events": "^8.0|^9.0|^10.0|^11.15",
+    "illuminate/support": "^8.0|^9.0|^10.0|^11.15"
   },
   "require-dev": {
     "mockery/mockery": "^1.5",

--- a/composer.json
+++ b/composer.json
@@ -25,10 +25,10 @@
   ],
   "require": {
     "php": "^7.3|^8.0",
-    "illuminate/container": "^8.0|^9.0|^10.0|^11.15",
-    "illuminate/database": "^8.0|^9.0|^10.0|^11.15",
-    "illuminate/events": "^8.0|^9.0|^10.0|^11.15",
-    "illuminate/support": "^8.0|^9.0|^10.0|^11.15"
+    "illuminate/container": "^8.0|^9.0|^10.0|^11.0",
+    "illuminate/database": "^8.0|^9.0|^10.0|^11.0",
+    "illuminate/events": "^8.0|^9.0|^10.0|^11.0",
+    "illuminate/support": "^8.0|^9.0|^10.0|^11.0"
   },
   "require-dev": {
     "mockery/mockery": "^1.5",

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,6 @@
     "illuminate/support": "^8.0|^9.0|^10.0|^11.15"
   },
   "require-dev": {
-    "doctrine/dbal": "^v2.10|^3.8",
     "mockery/mockery": "^1.5",
     "orchestra/testbench": "^6.0|^7.0|^8.0|^9.0",
     "phpunit/phpunit": "^8.5.23|^9.5|^10.5"

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
     "illuminate/support": "^8.0|^9.0|^10.0|^11.15"
   },
   "require-dev": {
+    "doctrine/dbal": "^3.8",
     "mockery/mockery": "^1.5",
     "orchestra/testbench": "^6.0|^7.0|^8.0|^9.0",
     "phpunit/phpunit": "^8.5.23|^9.5|^10.5"

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "illuminate/support": "^8.0|^9.0|^10.0|^11.15"
   },
   "require-dev": {
-    "doctrine/dbal": "^3.8",
+    "doctrine/dbal": "^v2.10|^3.8",
     "mockery/mockery": "^1.5",
     "orchestra/testbench": "^6.0|^7.0|^8.0|^9.0",
     "phpunit/phpunit": "^8.5.23|^9.5|^10.5"

--- a/src/Schema/Grammar.php
+++ b/src/Schema/Grammar.php
@@ -43,10 +43,12 @@ class Grammar extends MySqlGrammar
             throw new LogicException('This database driver does not support modifying columns on Laravel < 10.0.');
         }
 
+        $prefix = method_exists($blueprint, 'getPrefix') ? $blueprint->getPrefix() : $blueprint->prefix;
+
         $isColumnstoreTable = $connection->scalar(sprintf(
             "select exists (select 1 from information_schema.tables where table_schema = %s and table_name = %s and storage_type = 'COLUMNSTORE') as is_columnstore",
             $this->quoteString($connection->getDatabaseName()),
-            $this->quoteString($blueprint->getPrefix().$blueprint->getTable())
+            $this->quoteString($prefix.$blueprint->getTable())
         ));
 
         if (! $isColumnstoreTable) {

--- a/src/Schema/Grammar.php
+++ b/src/Schema/Grammar.php
@@ -39,6 +39,10 @@ class Grammar extends MySqlGrammar
      */
     public function compileChange(Blueprint $blueprint, Fluent $command, Connection $connection)
     {
+        if (version_compare(Application::VERSION, '10.0', '<')) {
+            throw new LogicException('This database driver does not support modifying columns on Laravel < 10.0.');
+        }
+
         $isColumnstoreTable = $connection->scalar(sprintf(
             "select exists (select 1 from information_schema.tables where table_schema = %s and table_name = %s and storage_type = 'COLUMNSTORE') as is_columnstore",
             $this->quoteString($connection->getDatabaseName()),

--- a/src/Schema/Grammar.php
+++ b/src/Schema/Grammar.php
@@ -6,9 +6,11 @@ use Exception;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\Grammars\MySqlGrammar;
+use Illuminate\Foundation\Application;
 use Illuminate\Support\Fluent;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
+use LogicException;
 use SingleStore\Laravel\Schema\Blueprint as SingleStoreBlueprint;
 use SingleStore\Laravel\Schema\Grammar\CompilesKeys;
 use SingleStore\Laravel\Schema\Grammar\ModifiesColumns;
@@ -23,6 +25,61 @@ class Grammar extends MySqlGrammar
         // Before anything kicks off, we need to add the SingleStore modifiers
         // so that they'll get used while the columns are all compiling.
         $this->addSingleStoreModifiers();
+    }
+
+    /**
+     * Compile a change column command into a series of SQL statements.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
+     * @param  \Illuminate\Database\Connection  $connection
+     * @return array|string
+     *
+     * @throws \RuntimeException
+     */
+    public function compileChange(Blueprint $blueprint, Fluent $command, Connection $connection)
+    {
+        if (version_compare(Application::VERSION, '10.0', '<')) {
+            throw new LogicException('This database driver does not support modifying columns on Laravel < 10.0.');
+        }
+
+        $isColumnstoreTable = $connection->scalar(sprintf(
+            "select exists (select 1 from information_schema.tables where table_schema = %s and table_name = %s and storage_type = 'COLUMNSTORE') as is_columnstore",
+            $this->quoteString($connection->getDatabaseName()),
+            $this->quoteString($blueprint->getPrefix().$blueprint->getTable())
+        ));
+
+        if (! $isColumnstoreTable) {
+            return parent::compileChange($blueprint, $command, $connection);
+        }
+
+        if (version_compare(Application::VERSION, '11.15', '<')) {
+            throw new LogicException('This database driver does not support modifying columns of a columnstore table on Laravel < 11.15.');
+        }
+
+        $tempCommand = clone $command;
+        $tempCommand->column = clone $command->column;
+        $tempCommand->column->change = false;
+        $tempCommand->column->name = '__temp__'.$command->column->name;
+        $tempCommand->column->after = is_null($command->column->after) && is_null($command->column->first)
+            ? $command->column->name
+            : $command->column->after;
+
+        return [
+            $this->compileAdd($blueprint, $tempCommand),
+            sprintf('update %s set %s = %s',
+                $this->wrapTable($blueprint),
+                $this->wrap($tempCommand->column),
+                $this->wrap($command->column)
+            ),
+            $this->compileDropColumn($blueprint, new Fluent([
+                'columns' => [$command->column->name],
+            ])),
+            $this->compileRenameColumn($blueprint, new Fluent([
+                'from' => $tempCommand->column->name,
+                'to' => $command->column->name,
+            ]), $connection),
+        ];
     }
 
     /**

--- a/src/Schema/Grammar.php
+++ b/src/Schema/Grammar.php
@@ -43,7 +43,11 @@ class Grammar extends MySqlGrammar
             throw new LogicException('This database driver does not support modifying columns on Laravel < 10.0.');
         }
 
-        $prefix = method_exists($blueprint, 'getPrefix') ? $blueprint->getPrefix() : $blueprint->prefix;
+        $prefix = method_exists($blueprint, 'getPrefix')
+            ? $blueprint->getPrefix()
+            : (function () {
+                return $this->prefix;
+            })->call($blueprint);
 
         $isColumnstoreTable = $connection->scalar(sprintf(
             "select exists (select 1 from information_schema.tables where table_schema = %s and table_name = %s and storage_type = 'COLUMNSTORE') as is_columnstore",

--- a/src/Schema/Grammar.php
+++ b/src/Schema/Grammar.php
@@ -39,10 +39,6 @@ class Grammar extends MySqlGrammar
      */
     public function compileChange(Blueprint $blueprint, Fluent $command, Connection $connection)
     {
-        if (version_compare(Application::VERSION, '10.0', '<')) {
-            throw new LogicException('This database driver does not support modifying columns on Laravel < 10.0.');
-        }
-
         $isColumnstoreTable = $connection->scalar(sprintf(
             "select exists (select 1 from information_schema.tables where table_schema = %s and table_name = %s and storage_type = 'COLUMNSTORE') as is_columnstore",
             $this->quoteString($connection->getDatabaseName()),

--- a/tests/Hybrid/ChangeColumnTest.php
+++ b/tests/Hybrid/ChangeColumnTest.php
@@ -5,6 +5,7 @@ namespace SingleStore\Laravel\Tests\Hybrid;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Schema;
 use SingleStore\Laravel\Schema\Blueprint;
+use SingleStore\Laravel\Schema\Builder;
 use SingleStore\Laravel\Tests\BaseTest;
 
 class ChangeColumnTest extends BaseTest
@@ -42,6 +43,10 @@ class ChangeColumnTest extends BaseTest
             $cached = $this->mockDatabaseConnection;
 
             $this->mockDatabaseConnection = false;
+
+            if (method_exists(Builder::class, 'useNativeSchemaOperationsIfPossible')) {
+                Schema::useNativeSchemaOperationsIfPossible();
+            }
 
             $this->createTable(function (Blueprint $table) {
                 $table->rowstore();

--- a/tests/Hybrid/ChangeColumnTest.php
+++ b/tests/Hybrid/ChangeColumnTest.php
@@ -12,26 +12,6 @@ class ChangeColumnTest extends BaseTest
 {
     use HybridTestHelpers;
 
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        if ($this->runHybridIntegrations()) {
-            $this->createTable(function (Blueprint $table) {
-                $table->id();
-            });
-        }
-    }
-
-    protected function tearDown(): void
-    {
-        if ($this->runHybridIntegrations()) {
-            Schema::dropIfExists('test_renamed');
-        }
-
-        parent::tearDown();
-    }
-
     /** @test */
     public function change_column_on_rowstore_table()
     {

--- a/tests/Hybrid/ChangeColumnTest.php
+++ b/tests/Hybrid/ChangeColumnTest.php
@@ -75,6 +75,29 @@ class ChangeColumnTest extends BaseTest
     }
 
     /** @test */
+    public function change_column_on_rowstore_table_with_doctrine()
+    {
+        if (! $this->runHybridIntegrations()) {
+            return;
+        }
+
+        $this->mockDatabaseConnection = false;
+
+        $this->createTable(function (Blueprint $table) {
+            $table->rowstore();
+            $table->id();
+            $table->string('data');
+        });
+
+        Schema::table('test', function (Blueprint $table) {
+            $table->text('data')->nullable()->change();
+        });
+
+        $this->assertEquals(['id', 'data'], Schema::getColumnListing('test'));
+        $this->assertEquals('text', Schema::getColumnType('test', 'data'));
+    }
+
+    /** @test */
     public function change_column_of_columnstore_table()
     {
         if (version_compare(Application::VERSION, '11.15', '<')) {

--- a/tests/Hybrid/ChangeColumnTest.php
+++ b/tests/Hybrid/ChangeColumnTest.php
@@ -38,8 +38,10 @@ class ChangeColumnTest extends BaseTest
                 $table->text('data')->nullable()->change();
             });
 
-            $this->assertEquals(['id', 'data'], Schema::getColumnListing('test'));
-            $this->assertEquals('text', Schema::getColumnType('test', 'data'));
+            if (version_compare(Application::VERSION, '10.30', '>=')) {
+                $this->assertEquals(['id', 'data'], Schema::getColumnListing('test'));
+                $this->assertEquals('text', Schema::getColumnType('test', 'data'));
+            }
 
             $this->mockDatabaseConnection = $cached;
         }

--- a/tests/Hybrid/ChangeColumnTest.php
+++ b/tests/Hybrid/ChangeColumnTest.php
@@ -9,7 +9,7 @@ use SingleStore\Laravel\Tests\BaseTest;
 
 class ChangeColumnTest extends BaseTest
 {
-    use \SingleStore\Laravel\Tests\Hybrid\HybridTestHelpers;
+    use HybridTestHelpers;
 
     protected function setUp(): void
     {
@@ -67,7 +67,7 @@ class ChangeColumnTest extends BaseTest
         $connection->shouldReceive('scalar')
             ->with("select exists (select 1 from information_schema.tables where table_schema = 'database' and table_name = 'test' and storage_type = 'COLUMNSTORE') as is_columnstore")
             ->andReturn(0);
-
+        $connection->shouldReceive('usingNativeSchemaOperations')->andReturn(true);
         $statements = $blueprint->toSql($connection, $this->getGrammar());
 
         $this->assertCount(1, $statements);

--- a/tests/Hybrid/ChangeColumnTest.php
+++ b/tests/Hybrid/ChangeColumnTest.php
@@ -38,8 +38,9 @@ class ChangeColumnTest extends BaseTest
                 $table->text('data')->nullable()->change();
             });
 
+            $this->assertEquals(['id', 'data'], Schema::getColumnListing('test'));
+
             if (version_compare(Application::VERSION, '10.30', '>=')) {
-                $this->assertEquals(['id', 'data'], Schema::getColumnListing('test'));
                 $this->assertEquals('text', Schema::getColumnType('test', 'data'));
             }
 

--- a/tests/Hybrid/ChangeColumnTest.php
+++ b/tests/Hybrid/ChangeColumnTest.php
@@ -80,29 +80,6 @@ class ChangeColumnTest extends BaseTest
     }
 
     /** @test */
-    public function change_column_on_rowstore_table_with_doctrine()
-    {
-        if (! $this->runHybridIntegrations()) {
-            return;
-        }
-
-        $this->mockDatabaseConnection = false;
-
-        $this->createTable(function (Blueprint $table) {
-            $table->rowstore();
-            $table->id();
-            $table->string('data');
-        });
-
-        Schema::table('test', function (Blueprint $table) {
-            $table->text('data')->nullable()->change();
-        });
-
-        $this->assertEquals(['id', 'data'], Schema::getColumnListing('test'));
-        $this->assertEquals('text', Schema::getColumnType('test', 'data'));
-    }
-
-    /** @test */
     public function change_column_of_columnstore_table()
     {
         if (version_compare(Application::VERSION, '11.15', '<')) {

--- a/tests/Hybrid/ChangeColumnTest.php
+++ b/tests/Hybrid/ChangeColumnTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace SingleStore\Laravel\Tests\Hybrid;
+
+use Illuminate\Foundation\Application;
+use Illuminate\Support\Facades\Schema;
+use SingleStore\Laravel\Schema\Blueprint;
+use SingleStore\Laravel\Tests\BaseTest;
+
+class ChangeColumnTest extends BaseTest
+{
+    use \SingleStore\Laravel\Tests\Hybrid\HybridTestHelpers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if ($this->runHybridIntegrations()) {
+            $this->createTable(function (Blueprint $table) {
+                $table->id();
+            });
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->runHybridIntegrations()) {
+            Schema::dropIfExists('test_renamed');
+        }
+
+        parent::tearDown();
+    }
+
+    /** @test */
+    public function change_column_on_rowstore_table()
+    {
+        if (version_compare(Application::VERSION, '10.0', '<')) {
+            $this->markTestSkipped('requires higher laravel version');
+        }
+
+        if ($this->runHybridIntegrations()) {
+            $cached = $this->mockDatabaseConnection;
+
+            $this->mockDatabaseConnection = false;
+
+            $this->createTable(function (Blueprint $table) {
+                $table->rowstore();
+                $table->id();
+                $table->string('data');
+            });
+
+            Schema::table('test', function (Blueprint $table) {
+                $table->text('data')->nullable()->change();
+            });
+
+            $this->assertEquals(['id', 'data'], Schema::getColumnListing('test'));
+            $this->assertEquals('text', Schema::getColumnType('test', 'data'));
+
+            $this->mockDatabaseConnection = $cached;
+        }
+
+        $blueprint = new Blueprint('test');
+        $blueprint->text('data')->nullable()->change();
+
+        $connection = $this->getConnection();
+        $connection->shouldReceive('getDatabaseName')->andReturn('database');
+        $connection->shouldReceive('scalar')
+            ->with("select exists (select 1 from information_schema.tables where table_schema = 'database' and table_name = 'test' and storage_type = 'COLUMNSTORE') as is_columnstore")
+            ->andReturn(0);
+
+        $statements = $blueprint->toSql($connection, $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table `test` modify `data` text null', $statements[0]);
+    }
+
+    /** @test */
+    public function change_column_of_columnstore_table()
+    {
+        if (version_compare(Application::VERSION, '11.15', '<')) {
+            $this->markTestSkipped('requires higher laravel version');
+        }
+
+        if ($this->runHybridIntegrations()) {
+            $cached = $this->mockDatabaseConnection;
+
+            $this->mockDatabaseConnection = false;
+
+            $this->createTable(function (Blueprint $table) {
+                $table->id();
+                $table->string('data');
+            });
+
+            Schema::table('test', function (Blueprint $table) {
+                $table->text('data')->nullable()->change();
+            });
+
+            $this->assertEquals(['id', 'data'], Schema::getColumnListing('test'));
+            $this->assertEquals('text', Schema::getColumnType('test', 'data'));
+
+            $this->mockDatabaseConnection = $cached;
+        }
+
+        $blueprint = new Blueprint('test');
+        $blueprint->text('data')->nullable()->change();
+
+        $connection = $this->getConnection();
+        $connection->shouldReceive('getDatabaseName')->andReturn('database');
+        $connection->shouldReceive('scalar')
+            ->with("select exists (select 1 from information_schema.tables where table_schema = 'database' and table_name = 'test' and storage_type = 'COLUMNSTORE') as is_columnstore")
+            ->andReturn(1);
+
+        $statements = $blueprint->toSql($connection, $this->getGrammar());
+
+        $this->assertCount(4, $statements);
+        $this->assertEquals([
+            'alter table `test` add `__temp__data` text null after `data`',
+            'update `test` set `__temp__data` = `data`',
+            'alter table `test` drop `data`',
+            'alter table `test` change `__temp__data` `data`',
+        ], $statements);
+    }
+}


### PR DESCRIPTION
Fixes #39

Add support for modifying columns on
* columnstore tables - requires Laravel > 11.15
* rowstore tables - requires Laravel > 10.0

Note 1: On Laravel 10.x, You have to call `Schema::useNativeSchemaOperationsIfPossible()` method within the `boot` method of your `App\Providers\AppServiceProvider` class. Not needed on Laravel 11.x

Note 2: I'm not sure how Singlestore handles indexes and foreign keys of the column being modified, couldn't find anything related on [the docs](https://docs.singlestore.com/cloud/reference/sql-reference/data-definition-language-ddl/alter-table/#alter-table-to-modify-column-data-types-sizes-and-collation).