### PR TITLE
Laravel 12 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,66 +18,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [7.3, 7.4, 8.0, 8.1, 8.2, 8.3, 8.4]
-        laravel: [8.*, 9.*, 10.*, 11.*]
+        php: [8.2, 8.3, 8.4]
+        laravel: [12.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 8.*
-            testbench: 6.*
-
-          - laravel: 9.*
-            testbench: 7.*
-
-          - laravel: 10.*
-            testbench: 8.*
-
-          - laravel: 11.*
-            testbench: 9.*
-
-        exclude:
-          # Laravel 8.0 has type incompatibilities with PHP 8.1.
-          - laravel: 8.*
-            php: 8.1
-            dependency-version: prefer-lowest
-
-          - laravel: 8.*
-            php: 8.2
-
-          - laravel: 8.*
-            php: 8.3
-
-          - laravel: 8.*
-            php: 8.4
-
-          # Laravel 9 requires PHP 8.0.
-          - laravel: 9.*
-            php: 7.3
-
-          - laravel: 9.*
-            php: 7.4
-
-          # Laravel 10 requires PHP 8.1
-          - laravel: 10.*
-            php: 7.3
-
-          - laravel: 10.*
-            php: 7.4
-
-          - laravel: 10.*
-            php: 8.0
-          
-          # Laravel 11 requires PHP 8.2
-          - laravel: 11.*
-            php: 7.3
-
-          - laravel: 11.*
-            php: 7.4
-
-          - laravel: 11.*
-            php: 8.0
-
-          - laravel: 11.*
-            php: 8.1
+          - laravel: 12.*
+            testbench: 10.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/composer.json
+++ b/composer.json
@@ -33,8 +33,7 @@
   "require-dev": {
     "mockery/mockery": "^1.6.10",
     "orchestra/testbench": "^10.0.0",
-    "phpunit/phpunit": "^10.5.35|^11.5.3|^12.0.1",
-    "spatie/laravel-ray": "^1.39"
+    "phpunit/phpunit": "^10.5.35|^11.5.3|^12.0.1"
   },
   "config": {
     "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -24,16 +24,17 @@
     }
   ],
   "require": {
-    "php": "^7.3|^8.0",
-    "illuminate/container": "^8.0|^9.0|^10.0|^11.0",
-    "illuminate/database": "^8.0|^9.0|^10.0|^11.0",
-    "illuminate/events": "^8.0|^9.0|^10.0|^11.0",
-    "illuminate/support": "^8.0|^9.0|^10.0|^11.0"
+    "php": "^8.2",
+    "illuminate/container": "^12.0",
+    "illuminate/database": "^12.0",
+    "illuminate/events": "^12.0",
+    "illuminate/support": "^12.0"
   },
   "require-dev": {
-    "mockery/mockery": "^1.5",
-    "orchestra/testbench": "^6.0|^7.0|^8.0|^9.0",
-    "phpunit/phpunit": "^8.5.23|^9.5|^10.5"
+    "mockery/mockery": "^1.6.10",
+    "orchestra/testbench": "^10.0.0",
+    "phpunit/phpunit": "^10.5.35|^11.5.3|^12.0.1",
+    "spatie/laravel-ray": "^1.39"
   },
   "config": {
     "sort-packages": true

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,13 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false"
-         backupStaticAttributes="false" colors="true" verbose="true" convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false"
-         stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-    <coverage>
-        <include>
-            <directory suffix=".php">src/</directory>
-        </include>
-    </coverage>
+<phpunit bootstrap="vendor/autoload.php"
+         backupGlobals="false"
+         colors="true"
+         processIsolation="false"
+         stopOnFailure="false">
     <testsuites>
         <testsuite name="unit">
             <directory>tests/Unit</directory>

--- a/src/Connect/Connection.php
+++ b/src/Connect/Connection.php
@@ -5,8 +5,8 @@ namespace SingleStore\Laravel\Connect;
 use Illuminate\Database\MySqlConnection;
 use SingleStore\Laravel\Query\SingleStoreQueryBuilder;
 use SingleStore\Laravel\Query\SingleStoreQueryGrammar;
-use SingleStore\Laravel\Schema\SingleStoreSchemaGrammar;
 use SingleStore\Laravel\Schema\SingleStoreSchemaBuilder;
+use SingleStore\Laravel\Schema\SingleStoreSchemaGrammar;
 
 class Connection extends MySqlConnection
 {
@@ -35,7 +35,7 @@ class Connection extends MySqlConnection
 
     /**
      * Get the default schema grammar instance.
-     * 
+     *
      * @return SingleStoreSchemaGrammar
      */
     protected function getDefaultSchemaGrammar()

--- a/src/Connect/Connection.php
+++ b/src/Connect/Connection.php
@@ -35,6 +35,8 @@ class Connection extends MySqlConnection
 
     /**
      * Get the default schema grammar instance.
+     * 
+     * @return SingleStoreSchemaGrammar
      */
     protected function getDefaultSchemaGrammar()
     {

--- a/src/Connect/SingleStoreConnection.php
+++ b/src/Connect/SingleStoreConnection.php
@@ -8,7 +8,7 @@ use SingleStore\Laravel\Query\SingleStoreQueryGrammar;
 use SingleStore\Laravel\Schema\SingleStoreSchemaBuilder;
 use SingleStore\Laravel\Schema\SingleStoreSchemaGrammar;
 
-class Connection extends MySqlConnection
+class SingleStoreConnection extends MySqlConnection
 {
     public function getSchemaBuilder()
     {

--- a/src/Connect/SingleStoreConnector.php
+++ b/src/Connect/SingleStoreConnector.php
@@ -4,4 +4,4 @@ namespace SingleStore\Laravel\Connect;
 
 use Illuminate\Database\Connectors\MySqlConnector;
 
-class Connector extends MySqlConnector {}
+class SingleStoreConnector extends MySqlConnector {}

--- a/src/Query/SingleStoreQueryBuilder.php
+++ b/src/Query/SingleStoreQueryBuilder.php
@@ -4,7 +4,7 @@ namespace SingleStore\Laravel\Query;
 
 use Illuminate\Database\Query\Builder as BaseBuilder;
 
-class Builder extends BaseBuilder
+class SingleStoreQueryBuilder extends BaseBuilder
 {
     public $options;
 

--- a/src/Query/SingleStoreQueryGrammar.php
+++ b/src/Query/SingleStoreQueryGrammar.php
@@ -3,18 +3,21 @@
 namespace SingleStore\Laravel\Query;
 
 use Exception;
+use Illuminate\Database\Connection;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Database\Query\Grammars\MySqlGrammar;
 use Illuminate\Support\Facades\Log;
 
-class Grammar extends MySqlGrammar
+class SingleStoreQueryGrammar extends MySqlGrammar
 {
     private $ignoreOrderByInDeletes;
 
     private $ignoreOrderByInUpdates;
 
-    public function __construct($ignoreOrderByInDeletes, $ignoreOrderByInUpdates)
+    public function __construct(Connection $connection, $ignoreOrderByInDeletes, $ignoreOrderByInUpdates)
     {
+        parent::__construct($connection);
+
         $this->ignoreOrderByInDeletes = $ignoreOrderByInDeletes;
         $this->ignoreOrderByInUpdates = $ignoreOrderByInUpdates;
     }

--- a/src/Schema/Blueprint.php
+++ b/src/Schema/Blueprint.php
@@ -3,10 +3,8 @@
 namespace SingleStore\Laravel\Schema;
 
 use Exception;
-use Illuminate\Database\Connection;
 use Illuminate\Database\QueryException;
 use Illuminate\Database\Schema\Blueprint as BaseBlueprint;
-use Illuminate\Database\Schema\Grammars\Grammar;
 use SingleStore\Laravel\Schema\Blueprint\AddsTableFlags;
 use SingleStore\Laravel\Schema\Blueprint\InlinesIndexes;
 use SingleStore\Laravel\Schema\Blueprint\ModifiesIndexes;
@@ -52,16 +50,16 @@ class Blueprint extends BaseBlueprint
      *
      * @return void
      */
-    public function build(Connection $connection, Grammar $grammar)
+    public function build()
     {
         try {
-            parent::build($connection, $grammar);
+            parent::build();
         } catch (QueryException $exception) {
             if (str_contains($exception->getMessage(), 'FULLTEXT KEY with unsupported type')) {
                 throw new Exception('FULLTEXT is not supported when using the utf8mb4 collation.');
-            } else {
-                throw $exception;
             }
+
+            throw $exception;
         }
     }
 }

--- a/src/Schema/Blueprint/InlinesIndexes.php
+++ b/src/Schema/Blueprint/InlinesIndexes.php
@@ -2,9 +2,7 @@
 
 namespace SingleStore\Laravel\Schema\Blueprint;
 
-use Illuminate\Database\Connection;
 use Illuminate\Database\Schema\Grammars\Grammar;
-use Illuminate\Foundation\Application;
 use Illuminate\Support\Arr;
 use SingleStore\Laravel\Schema\Blueprint as SingleStoreBlueprint;
 

--- a/src/Schema/Blueprint/InlinesIndexes.php
+++ b/src/Schema/Blueprint/InlinesIndexes.php
@@ -109,13 +109,9 @@ trait InlinesIndexes
         }
     }
 
-    public function toSql(Connection $connection, Grammar $grammar)
+    public function toSql()
     {
-        if (version_compare(Application::VERSION, '10.0.0', '>=')) {
-            $this->addImpliedCommands($connection, $grammar);
-        } else {
-            $this->addImpliedCommands($grammar);
-        }
+        $this->addImpliedCommands();
         $this->addFluentSingleStoreIndexes();
 
         $statements = [];
@@ -129,9 +125,10 @@ trait InlinesIndexes
             $method = 'compile'.ucfirst($command->name);
             $isIndex = $this->isIndexCommand($command);
 
-            if (method_exists($grammar, $method) || $grammar::hasMacro($method)) {
-                if (! is_null($sql = $grammar->$method($this, $command, $connection))) {
+            if (method_exists($this->grammar, $method) || $this->grammar::hasMacro($method)) {
+                if (! is_null($sql = $this->grammar->$method($this, $command))) {
                     $statements = array_merge($statements, (array) $sql);
+
                     if ($isIndex) {
                         array_push($indexStatementKeys, count($statements) - 1);
                     }

--- a/src/Schema/SingleStoreSchemaBuilder.php
+++ b/src/Schema/SingleStoreSchemaBuilder.php
@@ -5,7 +5,7 @@ namespace SingleStore\Laravel\Schema;
 use Closure;
 use Illuminate\Database\Schema\MySqlBuilder;
 
-class Builder extends MySqlBuilder
+class SingleStoreSchemaBuilder extends MySqlBuilder
 {
     /**
      * @param  string  $table

--- a/src/Schema/SingleStoreSchemaGrammar.php
+++ b/src/Schema/SingleStoreSchemaGrammar.php
@@ -15,13 +15,15 @@ use SingleStore\Laravel\Schema\Blueprint as SingleStoreBlueprint;
 use SingleStore\Laravel\Schema\Grammar\CompilesKeys;
 use SingleStore\Laravel\Schema\Grammar\ModifiesColumns;
 
-class Grammar extends MySqlGrammar
+class SingleStoreSchemaGrammar extends MySqlGrammar
 {
     use CompilesKeys;
     use ModifiesColumns;
 
-    public function __construct()
+    public function __construct(Connection $connection)
     {
+        parent::__construct($connection);
+
         // Before anything kicks off, we need to add the SingleStore modifiers
         // so that they'll get used while the columns are all compiling.
         $this->addSingleStoreModifiers();
@@ -34,30 +36,22 @@ class Grammar extends MySqlGrammar
      *
      * @throws \RuntimeException
      */
-    public function compileChange(Blueprint $blueprint, Fluent $command, Connection $connection)
+    public function compileChange(Blueprint $blueprint, Fluent $command)
     {
-        if (version_compare(Application::VERSION, '10.0', '<')) {
-            throw new LogicException('This database driver does not support modifying columns on Laravel < 10.0.');
-        }
-
         $prefix = method_exists($blueprint, 'getPrefix')
             ? $blueprint->getPrefix()
             : (function () {
                 return $this->prefix;
             })->call($blueprint);
 
-        $isColumnstoreTable = $connection->scalar(sprintf(
+        $isColumnstoreTable = $this->connection->scalar(sprintf(
             "select exists (select 1 from information_schema.tables where table_schema = %s and table_name = %s and storage_type = 'COLUMNSTORE') as is_columnstore",
-            $this->quoteString($connection->getDatabaseName()),
+            $this->quoteString($this->connection->getDatabaseName()),
             $this->quoteString($prefix.$blueprint->getTable())
         ));
 
         if (! $isColumnstoreTable) {
-            return parent::compileChange($blueprint, $command, $connection);
-        }
-
-        if (version_compare(Application::VERSION, '11.15', '<')) {
-            throw new LogicException('This database driver does not support modifying columns of a columnstore table on Laravel < 11.15.');
+            return parent::compileChange($blueprint, $command);
         }
 
         $tempCommand = clone $command;
@@ -81,7 +75,7 @@ class Grammar extends MySqlGrammar
             $this->compileRenameColumn($blueprint, new Fluent([
                 'from' => $tempCommand->column->name,
                 'to' => $command->column->name,
-            ]), $connection),
+            ])),
         ];
     }
 
@@ -124,17 +118,17 @@ class Grammar extends MySqlGrammar
      * @param  Blueprint  $blueprint
      * @param  \Illuminate\Support\Fluent  $command
      * @param  \Illuminate\Database\Connection  $connection
-     * @return array
+     * @return string
      *
      * @throws Exception
      */
-    protected function compileCreateTable($blueprint, $command, $connection)
+    protected function compileCreateTable($blueprint, $command): string
     {
         // We want to do as little as possible ourselves, so we rely on the parent
         // to compile everything and then potentially sneak some modifiers in.
         return $this->insertCreateTableModifiers(
             $blueprint,
-            parent::compileCreateTable($blueprint, $command, $connection)
+            parent::compileCreateTable($blueprint, $command)
         );
     }
 
@@ -162,9 +156,9 @@ class Grammar extends MySqlGrammar
      * @param  string  $sql
      * @return string
      */
-    protected function compileCreateEngine($sql, Connection $connection, Blueprint $blueprint)
+    protected function compileCreateEngine($sql, Blueprint $blueprint)
     {
-        $sql = parent::compileCreateEngine($sql, $connection, $blueprint);
+        $sql = parent::compileCreateEngine($sql, $blueprint);
 
         // We're not actually messing with the engine part at all, this is just
         // a good place to add `compression = sparse` if it's called for.
@@ -299,7 +293,7 @@ class Grammar extends MySqlGrammar
      *
      * @return array|string
      */
-    public function compileRenameColumn(Blueprint $blueprint, Fluent $command, Connection $connection)
+    public function compileRenameColumn(Blueprint $blueprint, Fluent $command)
     {
         return sprintf(
             'alter table %s change %s %s',

--- a/src/Schema/SingleStoreSchemaGrammar.php
+++ b/src/Schema/SingleStoreSchemaGrammar.php
@@ -6,11 +6,9 @@ use Exception;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\Grammars\MySqlGrammar;
-use Illuminate\Foundation\Application;
 use Illuminate\Support\Fluent;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
-use LogicException;
 use SingleStore\Laravel\Schema\Blueprint as SingleStoreBlueprint;
 use SingleStore\Laravel\Schema\Grammar\CompilesKeys;
 use SingleStore\Laravel\Schema\Grammar\ModifiesColumns;
@@ -47,7 +45,7 @@ class SingleStoreSchemaGrammar extends MySqlGrammar
         $isColumnstoreTable = $this->connection->scalar(sprintf(
             "select exists (select 1 from information_schema.tables where table_schema = %s and table_name = %s and storage_type = 'COLUMNSTORE') as is_columnstore",
             $this->quoteString($this->connection->getDatabaseName()),
-            $this->quoteString($prefix . $blueprint->getTable())
+            $this->quoteString($prefix.$blueprint->getTable())
         ));
 
         if (! $isColumnstoreTable) {
@@ -57,7 +55,7 @@ class SingleStoreSchemaGrammar extends MySqlGrammar
         $tempCommand = clone $command;
         $tempCommand->column = clone $command->column;
         $tempCommand->column->change = false;
-        $tempCommand->column->name = '__temp__' . $command->column->name;
+        $tempCommand->column->name = '__temp__'.$command->column->name;
         $tempCommand->column->after = is_null($command->column->after) && is_null($command->column->first)
             ? $command->column->name
             : $command->column->after;
@@ -119,7 +117,6 @@ class SingleStoreSchemaGrammar extends MySqlGrammar
      * @param  Blueprint  $blueprint
      * @param  \Illuminate\Support\Fluent  $command
      * @param  \Illuminate\Database\Connection  $connection
-     * @return string
      *
      * @throws Exception
      */
@@ -259,7 +256,7 @@ class SingleStoreSchemaGrammar extends MySqlGrammar
         $wrapped = array_map([$this, 'wrap'], $columns);
 
         return implode(', ', array_map(function ($column) use ($direction) {
-            return $column . ' ' . $direction;
+            return $column.' '.$direction;
         }, $wrapped));
     }
 
@@ -286,7 +283,7 @@ class SingleStoreSchemaGrammar extends MySqlGrammar
     {
         $from = $this->wrapTable($blueprint);
 
-        return "alter table {$from} rename to " . $this->wrapTable($command->to);
+        return "alter table {$from} rename to ".$this->wrapTable($command->to);
     }
 
     /**
@@ -315,11 +312,11 @@ class SingleStoreSchemaGrammar extends MySqlGrammar
     {
         return sprintf(
             'select column_name as `name`, data_type as `type_name`, column_type as `type`, '
-                . 'collation_name as `collation`, is_nullable as `nullable`, '
-                . 'column_default as `default`, column_comment as `comment`, '
-                . '"" as `expression`, extra as `extra` '
-                . 'from information_schema.columns where table_schema = %s and table_name = %s '
-                . 'order by ordinal_position asc',
+                .'collation_name as `collation`, is_nullable as `nullable`, '
+                .'column_default as `default`, column_comment as `comment`, '
+                .'"" as `expression`, extra as `extra` '
+                .'from information_schema.columns where table_schema = %s and table_name = %s '
+                .'order by ordinal_position asc',
             $database ? $this->quoteString($database) : 'database()',
             $this->quoteString($table)
         );

--- a/src/Schema/SingleStoreSchemaGrammar.php
+++ b/src/Schema/SingleStoreSchemaGrammar.php
@@ -47,7 +47,7 @@ class SingleStoreSchemaGrammar extends MySqlGrammar
         $isColumnstoreTable = $this->connection->scalar(sprintf(
             "select exists (select 1 from information_schema.tables where table_schema = %s and table_name = %s and storage_type = 'COLUMNSTORE') as is_columnstore",
             $this->quoteString($this->connection->getDatabaseName()),
-            $this->quoteString($prefix.$blueprint->getTable())
+            $this->quoteString($prefix . $blueprint->getTable())
         ));
 
         if (! $isColumnstoreTable) {
@@ -57,14 +57,15 @@ class SingleStoreSchemaGrammar extends MySqlGrammar
         $tempCommand = clone $command;
         $tempCommand->column = clone $command->column;
         $tempCommand->column->change = false;
-        $tempCommand->column->name = '__temp__'.$command->column->name;
+        $tempCommand->column->name = '__temp__' . $command->column->name;
         $tempCommand->column->after = is_null($command->column->after) && is_null($command->column->first)
             ? $command->column->name
             : $command->column->after;
 
         return [
             $this->compileAdd($blueprint, $tempCommand),
-            sprintf('update %s set %s = %s',
+            sprintf(
+                'update %s set %s = %s',
                 $this->wrapTable($blueprint),
                 $this->wrap($tempCommand->column),
                 $this->wrap($command->column)
@@ -258,7 +259,7 @@ class SingleStoreSchemaGrammar extends MySqlGrammar
         $wrapped = array_map([$this, 'wrap'], $columns);
 
         return implode(', ', array_map(function ($column) use ($direction) {
-            return $column.' '.$direction;
+            return $column . ' ' . $direction;
         }, $wrapped));
     }
 
@@ -285,7 +286,7 @@ class SingleStoreSchemaGrammar extends MySqlGrammar
     {
         $from = $this->wrapTable($blueprint);
 
-        return "alter table {$from} rename to ".$this->wrapTable($command->to);
+        return "alter table {$from} rename to " . $this->wrapTable($command->to);
     }
 
     /**
@@ -314,12 +315,12 @@ class SingleStoreSchemaGrammar extends MySqlGrammar
     {
         return sprintf(
             'select column_name as `name`, data_type as `type_name`, column_type as `type`, '
-                .'collation_name as `collation`, is_nullable as `nullable`, '
-                .'column_default as `default`, column_comment as `comment`, '
-                .'"" as `expression`, extra as `extra` '
-                .'from information_schema.columns where table_schema = %s and table_name = %s '
-                .'order by ordinal_position asc',
-            $this->quoteString($database),
+                . 'collation_name as `collation`, is_nullable as `nullable`, '
+                . 'column_default as `default`, column_comment as `comment`, '
+                . '"" as `expression`, extra as `extra` '
+                . 'from information_schema.columns where table_schema = %s and table_name = %s '
+                . 'order by ordinal_position asc',
+            $database ? $this->quoteString($database) : 'database()',
             $this->quoteString($table)
         );
     }

--- a/src/SingleStoreProvider.php
+++ b/src/SingleStoreProvider.php
@@ -3,8 +3,8 @@
 namespace SingleStore\Laravel;
 
 use Illuminate\Support\ServiceProvider;
-use SingleStore\Laravel\Connect\Connection;
-use SingleStore\Laravel\Connect\Connector;
+use SingleStore\Laravel\Connect\SingleStoreConnection;
+use SingleStore\Laravel\Connect\SingleStoreConnector;
 
 class SingleStoreProvider extends ServiceProvider
 {
@@ -13,13 +13,13 @@ class SingleStoreProvider extends ServiceProvider
      */
     public function register(): void
     {
-        Connection::resolverFor('singlestore', function ($connection, $database, $prefix, $config) {
-            return new Connection($connection, $database, $prefix, $config);
+        SingleStoreConnection::resolverFor('singlestore', function ($connection, $database, $prefix, $config) {
+            return new SingleStoreConnection($connection, $database, $prefix, $config);
         });
     }
 
     public function boot()
     {
-        $this->app->bind('db.connector.singlestore', Connector::class);
+        $this->app->bind('db.connector.singlestore', SingleStoreConnector::class);
     }
 }

--- a/tests/Hybrid/ChangeColumnTest.php
+++ b/tests/Hybrid/ChangeColumnTest.php
@@ -2,13 +2,11 @@
 
 namespace SingleStore\Laravel\Tests\Hybrid;
 
-use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Schema;
 use PHPUnit\Framework\Attributes\Test;
-use SingleStore\Laravel\Query\SingleStoreQueryGrammar;
 use SingleStore\Laravel\Schema\Blueprint;
-use SingleStore\Laravel\Schema\SingleStoreSchemaGrammar;
 use SingleStore\Laravel\Schema\SingleStoreSchemaBuilder;
+use SingleStore\Laravel\Schema\SingleStoreSchemaGrammar;
 use SingleStore\Laravel\Tests\BaseTest;
 
 class ChangeColumnTest extends BaseTest
@@ -37,8 +35,8 @@ class ChangeColumnTest extends BaseTest
                 $table->text('data')->nullable()->change();
             });
 
-            $this->assertEquals(['id', 'data'], Schema::getColumnListing("test"));
-            $this->assertEquals('text', Schema::getColumnType("test", 'data'));
+            $this->assertEquals(['id', 'data'], Schema::getColumnListing('test'));
+            $this->assertEquals('text', Schema::getColumnType('test', 'data'));
 
             $this->mockDatabaseConnection = $cached;
         }
@@ -80,8 +78,8 @@ class ChangeColumnTest extends BaseTest
                 $table->text('data')->nullable()->change();
             });
 
-            $this->assertEquals(['id', 'data'], Schema::getColumnListing("test"));
-            $this->assertEquals('text', Schema::getColumnType("test", 'data'));
+            $this->assertEquals(['id', 'data'], Schema::getColumnListing('test'));
+            $this->assertEquals('text', Schema::getColumnType('test', 'data'));
 
             $this->mockDatabaseConnection = $cached;
         }

--- a/tests/Hybrid/ChangeColumnTest.php
+++ b/tests/Hybrid/ChangeColumnTest.php
@@ -4,27 +4,26 @@ namespace SingleStore\Laravel\Tests\Hybrid;
 
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
+use SingleStore\Laravel\Query\SingleStoreQueryGrammar;
 use SingleStore\Laravel\Schema\Blueprint;
-use SingleStore\Laravel\Schema\Builder;
+use SingleStore\Laravel\Schema\SingleStoreSchemaGrammar;
+use SingleStore\Laravel\Schema\SingleStoreSchemaBuilder;
 use SingleStore\Laravel\Tests\BaseTest;
 
 class ChangeColumnTest extends BaseTest
 {
     use HybridTestHelpers;
 
-    /** @test */
+    #[Test]
     public function change_column_on_rowstore_table()
     {
-        if (version_compare(Application::VERSION, '10.0', '<')) {
-            $this->markTestSkipped('requires higher laravel version');
-        }
-
         if ($this->runHybridIntegrations()) {
             $cached = $this->mockDatabaseConnection;
 
             $this->mockDatabaseConnection = false;
 
-            if (method_exists(Builder::class, 'useNativeSchemaOperationsIfPossible')) {
+            if (method_exists(SingleStoreSchemaBuilder::class, 'useNativeSchemaOperationsIfPossible')) {
                 Schema::useNativeSchemaOperationsIfPossible();
             }
 
@@ -38,37 +37,36 @@ class ChangeColumnTest extends BaseTest
                 $table->text('data')->nullable()->change();
             });
 
-            $this->assertEquals(['id', 'data'], Schema::getColumnListing('test'));
-
-            if (version_compare(Application::VERSION, '10.30', '>=')) {
-                $this->assertEquals('text', Schema::getColumnType('test', 'data'));
-            }
+            $database = $this->getConnection()->getDatabaseName();
+            $this->assertEquals(['id', 'data'], Schema::getColumnListing("$database.test"));
+            $this->assertEquals('text', Schema::getColumnType("$database.test", 'data'));
 
             $this->mockDatabaseConnection = $cached;
         }
 
-        $blueprint = new Blueprint('test');
-        $blueprint->text('data')->nullable()->change();
-
         $connection = $this->getConnection();
+        $grammar = new SingleStoreSchemaGrammar($connection);
+
+        $connection->shouldReceive('getSchemaGrammar')->andReturn($grammar);
         $connection->shouldReceive('getDatabaseName')->andReturn('database');
+        $connection->shouldReceive('getTablePrefix')->andReturn('');
         $connection->shouldReceive('scalar')
             ->with("select exists (select 1 from information_schema.tables where table_schema = 'database' and table_name = 'test' and storage_type = 'COLUMNSTORE') as is_columnstore")
             ->andReturn(0);
         $connection->shouldReceive('usingNativeSchemaOperations')->andReturn(true);
-        $statements = $blueprint->toSql($connection, $this->getGrammar());
+
+        $blueprint = new Blueprint($connection, 'test');
+        $blueprint->text('data')->nullable()->change();
+
+        $statements = $blueprint->toSql();
 
         $this->assertCount(1, $statements);
         $this->assertEquals('alter table `test` modify `data` text null', $statements[0]);
     }
 
-    /** @test */
+    #[Test]
     public function change_column_of_columnstore_table()
     {
-        if (version_compare(Application::VERSION, '11.15', '<')) {
-            $this->markTestSkipped('requires higher laravel version');
-        }
-
         if ($this->runHybridIntegrations()) {
             $cached = $this->mockDatabaseConnection;
 
@@ -83,20 +81,25 @@ class ChangeColumnTest extends BaseTest
                 $table->text('data')->nullable()->change();
             });
 
-            $this->assertEquals(['id', 'data'], Schema::getColumnListing('test'));
-            $this->assertEquals('text', Schema::getColumnType('test', 'data'));
+            $database = $this->getConnection()->getDatabaseName();
+            $this->assertEquals(['id', 'data'], Schema::getColumnListing("$database.test"));
+            $this->assertEquals('text', Schema::getColumnType("$database.test", 'data'));
 
             $this->mockDatabaseConnection = $cached;
         }
 
-        $blueprint = new Blueprint('test');
-        $blueprint->text('data')->nullable()->change();
+        $connection = $this->getConnection('test');
+        $grammar = new SingleStoreSchemaGrammar($connection);
 
-        $connection = $this->getConnection();
+        $connection->shouldReceive('getSchemaGrammar')->andReturn($grammar);
         $connection->shouldReceive('getDatabaseName')->andReturn('database');
+        $connection->shouldReceive('getTablePrefix')->andReturn('');
         $connection->shouldReceive('scalar')
             ->with("select exists (select 1 from information_schema.tables where table_schema = 'database' and table_name = 'test' and storage_type = 'COLUMNSTORE') as is_columnstore")
             ->andReturn(1);
+
+        $blueprint = new Blueprint($connection, 'test');
+        $blueprint->text('data')->nullable()->change();
 
         $statements = $blueprint->toSql($connection, $this->getGrammar());
 

--- a/tests/Hybrid/ChangeColumnTest.php
+++ b/tests/Hybrid/ChangeColumnTest.php
@@ -37,9 +37,8 @@ class ChangeColumnTest extends BaseTest
                 $table->text('data')->nullable()->change();
             });
 
-            $database = $this->getConnection()->getDatabaseName();
-            $this->assertEquals(['id', 'data'], Schema::getColumnListing("$database.test"));
-            $this->assertEquals('text', Schema::getColumnType("$database.test", 'data'));
+            $this->assertEquals(['id', 'data'], Schema::getColumnListing("test"));
+            $this->assertEquals('text', Schema::getColumnType("test", 'data'));
 
             $this->mockDatabaseConnection = $cached;
         }
@@ -81,9 +80,8 @@ class ChangeColumnTest extends BaseTest
                 $table->text('data')->nullable()->change();
             });
 
-            $database = $this->getConnection()->getDatabaseName();
-            $this->assertEquals(['id', 'data'], Schema::getColumnListing("$database.test"));
-            $this->assertEquals('text', Schema::getColumnType("$database.test", 'data'));
+            $this->assertEquals(['id', 'data'], Schema::getColumnListing("test"));
+            $this->assertEquals('text', Schema::getColumnType("test", 'data'));
 
             $this->mockDatabaseConnection = $cached;
         }

--- a/tests/Hybrid/CreateTable/ComputedColumnsTest.php
+++ b/tests/Hybrid/CreateTable/ComputedColumnsTest.php
@@ -3,6 +3,7 @@
 namespace SingleStore\Laravel\Tests\Hybrid\CreateTable;
 
 use Exception;
+use PHPUnit\Framework\Attributes\Test;
 use SingleStore\Laravel\Schema\Blueprint;
 use SingleStore\Laravel\Tests\BaseTest;
 use SingleStore\Laravel\Tests\Hybrid\HybridTestHelpers;
@@ -11,7 +12,7 @@ class ComputedColumnsTest extends BaseTest
 {
     use HybridTestHelpers;
 
-    /** @test */
+    #[Test]
     public function computed_virtual_throws_an_exception()
     {
         $this->expectException(Exception::class);
@@ -24,7 +25,7 @@ class ComputedColumnsTest extends BaseTest
         $this->assertCreateStatement($blueprint, 'Argument is moot, exception will be thrown.');
     }
 
-    /** @test */
+    #[Test]
     public function computed_stored()
     {
         $blueprint = $this->createTable(function (Blueprint $table) {

--- a/tests/Hybrid/CreateTable/IncrementWithoutPrimaryKeyTest.php
+++ b/tests/Hybrid/CreateTable/IncrementWithoutPrimaryKeyTest.php
@@ -2,11 +2,10 @@
 
 namespace SingleStore\Laravel\Tests\Hybrid\CreateTable;
 
-use Illuminate\Foundation\Application;
+use PHPUnit\Framework\Attributes\Test;
 use SingleStore\Laravel\Schema\Blueprint;
 use SingleStore\Laravel\Tests\BaseTest;
 use SingleStore\Laravel\Tests\Hybrid\HybridTestHelpers;
-use PHPUnit\Framework\Attributes\Test;
 
 class IncrementWithoutPrimaryKeyTest extends BaseTest
 {

--- a/tests/Hybrid/CreateTable/IncrementWithoutPrimaryKeyTest.php
+++ b/tests/Hybrid/CreateTable/IncrementWithoutPrimaryKeyTest.php
@@ -6,12 +6,13 @@ use Illuminate\Foundation\Application;
 use SingleStore\Laravel\Schema\Blueprint;
 use SingleStore\Laravel\Tests\BaseTest;
 use SingleStore\Laravel\Tests\Hybrid\HybridTestHelpers;
+use PHPUnit\Framework\Attributes\Test;
 
 class IncrementWithoutPrimaryKeyTest extends BaseTest
 {
     use HybridTestHelpers;
 
-    /** @test */
+    #[Test]
     public function it_adds_a_big_increments_without_primary_key()
     {
         $blueprint = $this->createTable(function (Blueprint $table) {
@@ -21,20 +22,13 @@ class IncrementWithoutPrimaryKeyTest extends BaseTest
             $table->primary(['id', 'uuid']);
         });
 
-        if (version_compare(Application::VERSION, '10.38.0', '>=')) {
-            $this->assertCreateStatement(
-                $blueprint,
-                'create table `test` (`id` bigint unsigned not null auto_increment, `uuid` char(36) not null, primary key (`id`, `uuid`))'
-            );
-        } else {
-            $this->assertCreateStatement(
-                $blueprint,
-                'create table `test` (`id` bigint unsigned not null auto_increment, `uuid` char(36) not null, primary key `test_id_uuid_primary`(`id`, `uuid`))'
-            );
-        }
+        $this->assertCreateStatement(
+            $blueprint,
+            'create table `test` (`id` bigint unsigned not null auto_increment, `uuid` char(36) not null, primary key (`id`, `uuid`))'
+        );
     }
 
-    /** @test */
+    #[Test]
     public function it_adds_an_id_without_primary_key()
     {
         $blueprint = $this->createTable(function (Blueprint $table) {
@@ -44,16 +38,9 @@ class IncrementWithoutPrimaryKeyTest extends BaseTest
             $table->primary(['id', 'uuid']);
         });
 
-        if (version_compare(Application::VERSION, '10.38.0', '>=')) {
-            $this->assertCreateStatement(
-                $blueprint,
-                'create table `test` (`id` bigint unsigned not null auto_increment, `uuid` char(36) not null, primary key (`id`, `uuid`))'
-            );
-        } else {
-            $this->assertCreateStatement(
-                $blueprint,
-                'create table `test` (`id` bigint unsigned not null auto_increment, `uuid` char(36) not null, primary key `test_id_uuid_primary`(`id`, `uuid`))'
-            );
-        }
+        $this->assertCreateStatement(
+            $blueprint,
+            'create table `test` (`id` bigint unsigned not null auto_increment, `uuid` char(36) not null, primary key (`id`, `uuid`))'
+        );
     }
 }

--- a/tests/Hybrid/CreateTable/MiscCreateTest.php
+++ b/tests/Hybrid/CreateTable/MiscCreateTest.php
@@ -3,6 +3,7 @@
 namespace SingleStore\Laravel\Tests\Hybrid\CreateTable;
 
 use Illuminate\Foundation\Application;
+use PHPUnit\Framework\Attributes\Test;
 use SingleStore\Laravel\Schema\Blueprint;
 use SingleStore\Laravel\Tests\BaseTest;
 use SingleStore\Laravel\Tests\Hybrid\HybridTestHelpers;
@@ -11,7 +12,7 @@ class MiscCreateTest extends BaseTest
 {
     use HybridTestHelpers;
 
-    /** @test */
+    #[Test]
     public function all_keys_are_added_in_create_columnstore()
     {
         $blueprint = $this->createTable(function (Blueprint $table) {
@@ -21,20 +22,13 @@ class MiscCreateTest extends BaseTest
             $table->index('foo', 'name3', 'hash');
         });
 
-        if (version_compare(Application::VERSION, '10.38.0', '>=')) {
-            $this->assertCreateStatement(
-                $blueprint,
-                'create table `test` (`primary` varchar(255) not null, `index` varchar(255) not null, `foo` varchar(255) not null, index `name3` using hash(`foo`), index `name2`(`index`), primary key (`primary`))'
-            );
-        } else {
-            $this->assertCreateStatement(
-                $blueprint,
-                'create table `test` (`primary` varchar(255) not null, `index` varchar(255) not null, `foo` varchar(255) not null, index `name3` using hash(`foo`), primary key `name1`(`primary`), index `name2`(`index`))'
-            );
-        }
+        $this->assertCreateStatement(
+            $blueprint,
+            'create table `test` (`primary` varchar(255) not null, `index` varchar(255) not null, `foo` varchar(255) not null, index `name3` using hash(`foo`), index `name2`(`index`), primary key (`primary`))'
+        );
     }
 
-    /** @test */
+    #[Test]
     public function all_keys_are_added_in_create_rowstore()
     {
         $blueprint = $this->createTable(function (Blueprint $table) {
@@ -44,20 +38,13 @@ class MiscCreateTest extends BaseTest
             $table->geography('georegion')->spatialIndex('name3');
         });
 
-        if (version_compare(Application::VERSION, '10.38.0', '>=')) {
-            $this->assertCreateStatement(
-                $blueprint,
-                'create rowstore table `test` (`primary` varchar(255) not null, `index` varchar(255) not null, `georegion` geography not null, index `name2`(`index`), index `name3`(`georegion`), primary key (`primary`))'
-            );
-        } else {
-            $this->assertCreateStatement(
-                $blueprint,
-                'create rowstore table `test` (`primary` varchar(255) not null, `index` varchar(255) not null, `georegion` geography not null, primary key `name1`(`primary`), index `name2`(`index`), index `name3`(`georegion`))'
-            );
-        }
+        $this->assertCreateStatement(
+            $blueprint,
+            'create rowstore table `test` (`primary` varchar(255) not null, `index` varchar(255) not null, `georegion` geography not null, index `name2`(`index`), index `name3`(`georegion`), primary key (`primary`))'
+        );
     }
 
-    /** @test */
+    #[Test]
     public function medium_integer_id()
     {
         $blueprint = $this->createTable(function (Blueprint $table) {
@@ -70,7 +57,7 @@ class MiscCreateTest extends BaseTest
         );
     }
 
-    /** @test */
+    #[Test]
     public function discussion_53()
     {
         $blueprint = $this->createTable(function (Blueprint $table) {
@@ -83,20 +70,13 @@ class MiscCreateTest extends BaseTest
             $table->timestamps();
         });
 
-        if (version_compare(Application::VERSION, '10.38.0', '>=')) {
-            $this->assertCreateStatement(
-                $blueprint,
-                'create table `test` (`id` bigint unsigned not null auto_increment, `user_id` bigint unsigned not null, `template_id` varchar(255) not null, `data` longtext not null, `response_status_code` varchar(255) not null, `response_message` longtext not null, `created_at` timestamp null, `updated_at` timestamp null, index `test_id_index`(`id`), shard key(`user_id`))'
-            );
-        } else {
-            $this->assertCreateStatement(
-                $blueprint,
-                'create table `test` (`id` bigint unsigned not null auto_increment, `user_id` bigint unsigned not null, `template_id` varchar(255) not null, `data` longtext not null, `response_status_code` varchar(255) not null, `response_message` longtext not null, `created_at` timestamp null, `updated_at` timestamp null, index `test_id_index`(`id`), shard key(`user_id`))'
-            );
-        }
+        $this->assertCreateStatement(
+            $blueprint,
+            'create table `test` (`id` bigint unsigned not null auto_increment, `user_id` bigint unsigned not null, `template_id` varchar(255) not null, `data` longtext not null, `response_status_code` varchar(255) not null, `response_message` longtext not null, `created_at` timestamp null, `updated_at` timestamp null, index `test_id_index`(`id`), shard key(`user_id`))'
+        );
     }
 
-    /** @test */
+    #[Test]
     public function json_column()
     {
         $blueprint = $this->createTable(function (Blueprint $table) {

--- a/tests/Hybrid/CreateTable/MiscCreateTest.php
+++ b/tests/Hybrid/CreateTable/MiscCreateTest.php
@@ -2,7 +2,6 @@
 
 namespace SingleStore\Laravel\Tests\Hybrid\CreateTable;
 
-use Illuminate\Foundation\Application;
 use PHPUnit\Framework\Attributes\Test;
 use SingleStore\Laravel\Schema\Blueprint;
 use SingleStore\Laravel\Tests\BaseTest;

--- a/tests/Hybrid/CreateTable/SeriesTimestampTest.php
+++ b/tests/Hybrid/CreateTable/SeriesTimestampTest.php
@@ -5,12 +5,13 @@ namespace SingleStore\Laravel\Tests\Hybrid\CreateTable;
 use SingleStore\Laravel\Schema\Blueprint;
 use SingleStore\Laravel\Tests\BaseTest;
 use SingleStore\Laravel\Tests\Hybrid\HybridTestHelpers;
+use PHPUnit\Framework\Attributes\Test;
 
 class SeriesTimestampTest extends BaseTest
 {
     use HybridTestHelpers;
 
-    /** @test */
+    #[Test]
     public function series_timestamp()
     {
         $blueprint = $this->createTable(function (Blueprint $table) {
@@ -23,7 +24,7 @@ class SeriesTimestampTest extends BaseTest
         );
     }
 
-    /** @test */
+    #[Test]
     public function series_timestamp_sparse()
     {
         $blueprint = $this->createTable(function (Blueprint $table) {

--- a/tests/Hybrid/CreateTable/SeriesTimestampTest.php
+++ b/tests/Hybrid/CreateTable/SeriesTimestampTest.php
@@ -2,10 +2,10 @@
 
 namespace SingleStore\Laravel\Tests\Hybrid\CreateTable;
 
+use PHPUnit\Framework\Attributes\Test;
 use SingleStore\Laravel\Schema\Blueprint;
 use SingleStore\Laravel\Tests\BaseTest;
 use SingleStore\Laravel\Tests\Hybrid\HybridTestHelpers;
-use PHPUnit\Framework\Attributes\Test;
 
 class SeriesTimestampTest extends BaseTest
 {

--- a/tests/Hybrid/CreateTable/ShardKeysTest.php
+++ b/tests/Hybrid/CreateTable/ShardKeysTest.php
@@ -2,10 +2,10 @@
 
 namespace SingleStore\Laravel\Tests\Hybrid\CreateTable;
 
+use PHPUnit\Framework\Attributes\Test;
 use SingleStore\Laravel\Schema\Blueprint;
 use SingleStore\Laravel\Tests\BaseTest;
 use SingleStore\Laravel\Tests\Hybrid\HybridTestHelpers;
-use PHPUnit\Framework\Attributes\Test;
 
 class ShardKeysTest extends BaseTest
 {

--- a/tests/Hybrid/CreateTable/ShardKeysTest.php
+++ b/tests/Hybrid/CreateTable/ShardKeysTest.php
@@ -5,12 +5,13 @@ namespace SingleStore\Laravel\Tests\Hybrid\CreateTable;
 use SingleStore\Laravel\Schema\Blueprint;
 use SingleStore\Laravel\Tests\BaseTest;
 use SingleStore\Laravel\Tests\Hybrid\HybridTestHelpers;
+use PHPUnit\Framework\Attributes\Test;
 
 class ShardKeysTest extends BaseTest
 {
     use HybridTestHelpers;
 
-    /** @test */
+    #[Test]
     public function it_adds_a_shard_key_standalone()
     {
         $blueprint = $this->createTable(function (Blueprint $table) {
@@ -25,7 +26,7 @@ class ShardKeysTest extends BaseTest
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_adds_a_shard_key_fluent()
     {
         $blueprint = $this->createTable(function (Blueprint $table) {
@@ -38,7 +39,7 @@ class ShardKeysTest extends BaseTest
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_adds_a_dual_shard_key()
     {
         $blueprint = $this->createTable(function (Blueprint $table) {

--- a/tests/Hybrid/CreateTable/SortKeysTest.php
+++ b/tests/Hybrid/CreateTable/SortKeysTest.php
@@ -6,12 +6,13 @@ use InvalidArgumentException;
 use SingleStore\Laravel\Schema\Blueprint;
 use SingleStore\Laravel\Tests\BaseTest;
 use SingleStore\Laravel\Tests\Hybrid\HybridTestHelpers;
+use PHPUnit\Framework\Attributes\Test;
 
 class SortKeysTest extends BaseTest
 {
     use HybridTestHelpers;
 
-    /** @test */
+    #[Test]
     public function it_adds_a_sort_key_standalone()
     {
         $blueprint = $this->createTable(function (Blueprint $table) {
@@ -25,7 +26,7 @@ class SortKeysTest extends BaseTest
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_adds_a_sort_key_with_desc_direction_standalone()
     {
         $blueprint = $this->createTable(function (Blueprint $table) {
@@ -39,7 +40,7 @@ class SortKeysTest extends BaseTest
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_adds_a_sort_key_fluent()
     {
         $blueprint = $this->createTable(function (Blueprint $table) {
@@ -52,7 +53,7 @@ class SortKeysTest extends BaseTest
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_adds_a_sort_key_with_desc_direction_fluent()
     {
         $blueprint = $this->createTable(function (Blueprint $table) {
@@ -65,7 +66,7 @@ class SortKeysTest extends BaseTest
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_adds_a_dual_sort_key()
     {
         $blueprint = $this->createTable(function (Blueprint $table) {
@@ -80,7 +81,7 @@ class SortKeysTest extends BaseTest
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_adds_a_dual_sort_key_with_desc_direction()
     {
         $blueprint = $this->createTable(function (Blueprint $table) {
@@ -95,7 +96,7 @@ class SortKeysTest extends BaseTest
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_adds_a_dual_sort_key_with_different_directions()
     {
         $blueprint = $this->createTable(function (Blueprint $table) {
@@ -110,7 +111,7 @@ class SortKeysTest extends BaseTest
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_cannot_add_a_dual_sort_key_with_only_one_direction()
     {
         $this->expectException(InvalidArgumentException::class);
@@ -124,7 +125,7 @@ class SortKeysTest extends BaseTest
         $blueprint->toSql($this->getConnection(), $this->getGrammar());
     }
 
-    /** @test */
+    #[Test]
     public function it_cannot_add_a_dual_sort_key_with_only_one_direction_desc()
     {
         $this->expectException(InvalidArgumentException::class);
@@ -138,7 +139,7 @@ class SortKeysTest extends BaseTest
         $blueprint->toSql($this->getConnection(), $this->getGrammar());
     }
 
-    /** @test */
+    #[Test]
     public function shard_and_sort_keys()
     {
         $blueprint = $this->createTable(function (Blueprint $table) {
@@ -151,7 +152,7 @@ class SortKeysTest extends BaseTest
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_adds_a_sort_key_with_with_statement()
     {
         $blueprint = $this->createTable(function (Blueprint $table) {
@@ -165,7 +166,7 @@ class SortKeysTest extends BaseTest
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_adds_an_empty_sort_key_with_with_statement()
     {
         $blueprint = $this->createTable(function (Blueprint $table) {
@@ -179,7 +180,7 @@ class SortKeysTest extends BaseTest
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_adds_a_sort_key_fluent_with_with_statement()
     {
         $blueprint = $this->createTable(function (Blueprint $table) {
@@ -192,7 +193,7 @@ class SortKeysTest extends BaseTest
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_adds_a_sort_key_fluent_with_dual_with_statement()
     {
         $blueprint = $this->createTable(function (Blueprint $table) {

--- a/tests/Hybrid/CreateTable/SortKeysTest.php
+++ b/tests/Hybrid/CreateTable/SortKeysTest.php
@@ -3,10 +3,10 @@
 namespace SingleStore\Laravel\Tests\Hybrid\CreateTable;
 
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Test;
 use SingleStore\Laravel\Schema\Blueprint;
 use SingleStore\Laravel\Tests\BaseTest;
 use SingleStore\Laravel\Tests\Hybrid\HybridTestHelpers;
-use PHPUnit\Framework\Attributes\Test;
 
 class SortKeysTest extends BaseTest
 {

--- a/tests/Hybrid/CreateTable/SparseModifiersTest.php
+++ b/tests/Hybrid/CreateTable/SparseModifiersTest.php
@@ -2,7 +2,9 @@
 
 namespace SingleStore\Laravel\Tests\Hybrid\CreateTable;
 
+use PHPUnit\Framework\Attributes\Test;
 use SingleStore\Laravel\Schema\Blueprint;
+use SingleStore\Laravel\Schema\SingleStoreSchemaGrammar;
 use SingleStore\Laravel\Tests\BaseTest;
 use SingleStore\Laravel\Tests\Hybrid\HybridTestHelpers;
 
@@ -10,7 +12,7 @@ class SparseModifiersTest extends BaseTest
 {
     use HybridTestHelpers;
 
-    /** @test */
+    #[Test]
     public function sparse_column()
     {
         $blueprint = $this->createTable(function (Blueprint $table) {
@@ -25,7 +27,7 @@ class SparseModifiersTest extends BaseTest
         );
     }
 
-    /** @test */
+    #[Test]
     public function sparse_table()
     {
         $blueprint = $this->createTable(function (Blueprint $table) {
@@ -42,11 +44,18 @@ class SparseModifiersTest extends BaseTest
         );
     }
 
-    /** @test */
+    #[Test]
     public function sparse_with_after()
     {
         // See https://github.com/singlestore-labs/singlestoredb-laravel-driver/issues/18
-        $blueprint = new Blueprint('test');
+        $connection = $this->getConnection('test');
+        $grammar = new SingleStoreSchemaGrammar($connection);
+
+        $connection->shouldReceive('getSchemaGrammar')->andReturn($grammar);
+        $connection->shouldReceive('getTablePrefix')->andReturn('');
+        $connection->shouldReceive('getDatabaseName')->andReturn('database');
+
+        $blueprint = new Blueprint($connection, 'test');
 
         $blueprint->string('two_factor_secret')
             ->after('password')

--- a/tests/Hybrid/CreateTable/SpatialTest.php
+++ b/tests/Hybrid/CreateTable/SpatialTest.php
@@ -5,12 +5,13 @@ namespace SingleStore\Laravel\Tests\Hybrid\CreateTable;
 use SingleStore\Laravel\Schema\Blueprint;
 use SingleStore\Laravel\Tests\BaseTest;
 use SingleStore\Laravel\Tests\Hybrid\HybridTestHelpers;
+use PHPUnit\Framework\Attributes\Test;
 
 class SpatialTest extends BaseTest
 {
     use HybridTestHelpers;
 
-    /** @test */
+    #[Test]
     public function geography_without_resolution_fluent()
     {
         $blueprint = $this->createTable(function (Blueprint $table) {
@@ -25,7 +26,7 @@ class SpatialTest extends BaseTest
         );
     }
 
-    /** @test */
+    #[Test]
     public function geography_with_resolution()
     {
         $blueprint = $this->createTable(function (Blueprint $table) {
@@ -42,7 +43,7 @@ class SpatialTest extends BaseTest
         );
     }
 
-    /** @test */
+    #[Test]
     public function geography_point()
     {
         $blueprint = $this->createTable(function (Blueprint $table) {

--- a/tests/Hybrid/CreateTable/SpatialTest.php
+++ b/tests/Hybrid/CreateTable/SpatialTest.php
@@ -2,10 +2,10 @@
 
 namespace SingleStore\Laravel\Tests\Hybrid\CreateTable;
 
+use PHPUnit\Framework\Attributes\Test;
 use SingleStore\Laravel\Schema\Blueprint;
 use SingleStore\Laravel\Tests\BaseTest;
 use SingleStore\Laravel\Tests\Hybrid\HybridTestHelpers;
-use PHPUnit\Framework\Attributes\Test;
 
 class SpatialTest extends BaseTest
 {

--- a/tests/Hybrid/CreateTable/TableModifiersTest.php
+++ b/tests/Hybrid/CreateTable/TableModifiersTest.php
@@ -2,10 +2,10 @@
 
 namespace SingleStore\Laravel\Tests\Hybrid\CreateTable;
 
+use PHPUnit\Framework\Attributes\Test;
 use SingleStore\Laravel\Schema\Blueprint;
 use SingleStore\Laravel\Tests\BaseTest;
 use SingleStore\Laravel\Tests\Hybrid\HybridTestHelpers;
-use PHPUnit\Framework\Attributes\Test;
 
 class TableModifiersTest extends BaseTest
 {

--- a/tests/Hybrid/CreateTable/TableModifiersTest.php
+++ b/tests/Hybrid/CreateTable/TableModifiersTest.php
@@ -5,12 +5,13 @@ namespace SingleStore\Laravel\Tests\Hybrid\CreateTable;
 use SingleStore\Laravel\Schema\Blueprint;
 use SingleStore\Laravel\Tests\BaseTest;
 use SingleStore\Laravel\Tests\Hybrid\HybridTestHelpers;
+use PHPUnit\Framework\Attributes\Test;
 
 class TableModifiersTest extends BaseTest
 {
     use HybridTestHelpers;
 
-    //    /** @test */
+    //    #[Test]
     //    public function all_modifiers_together()
     //    {
     //        // This shouldn't actually be done, as it doesn't produce
@@ -31,7 +32,7 @@ class TableModifiersTest extends BaseTest
     //        );
     //    }
 
-    /** @test */
+    #[Test]
     public function it_creates_a_standard_temp()
     {
         $blueprint = $this->createTable(function (Blueprint $table) {
@@ -46,7 +47,7 @@ class TableModifiersTest extends BaseTest
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_creates_a_global_temp()
     {
         $blueprint = $this->createTable(function (Blueprint $table) {
@@ -63,7 +64,7 @@ class TableModifiersTest extends BaseTest
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_creates_a_global_temp_chained()
     {
         $blueprint = $this->createTable(function (Blueprint $table) {
@@ -78,7 +79,7 @@ class TableModifiersTest extends BaseTest
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_creates_a_global_temp_style_two()
     {
         $blueprint = $this->createTable(function (Blueprint $table) {
@@ -94,7 +95,7 @@ class TableModifiersTest extends BaseTest
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_creates_a_global_temp_rowstore()
     {
         $blueprint = $this->createTable(function (Blueprint $table) {
@@ -111,7 +112,7 @@ class TableModifiersTest extends BaseTest
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_creates_a_reference()
     {
         $blueprint = $this->createTable(function (Blueprint $table) {
@@ -126,7 +127,7 @@ class TableModifiersTest extends BaseTest
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_creates_a_rowstore_reference()
     {
         $blueprint = $this->createTable(function (Blueprint $table) {
@@ -143,7 +144,7 @@ class TableModifiersTest extends BaseTest
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_creates_a_default()
     {
         $blueprint = $this->createTable(function (Blueprint $table) {

--- a/tests/Hybrid/CreateTable/UniqueKeysTest.php
+++ b/tests/Hybrid/CreateTable/UniqueKeysTest.php
@@ -5,12 +5,13 @@ namespace SingleStore\Laravel\Tests\Hybrid\CreateTable;
 use SingleStore\Laravel\Schema\Blueprint;
 use SingleStore\Laravel\Tests\BaseTest;
 use SingleStore\Laravel\Tests\Hybrid\HybridTestHelpers;
+use PHPUnit\Framework\Attributes\Test;
 
 class UniqueKeysTest extends BaseTest
 {
     use HybridTestHelpers;
 
-    /** @test */
+    #[Test]
     public function it_adds_a_unique_key()
     {
         $blueprint = $this->createTable(function (Blueprint $table) {
@@ -27,7 +28,7 @@ class UniqueKeysTest extends BaseTest
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_adds_a_unique_key_reference_fluent()
     {
         $blueprint = $this->createTable(function (Blueprint $table) {

--- a/tests/Hybrid/CreateTable/UniqueKeysTest.php
+++ b/tests/Hybrid/CreateTable/UniqueKeysTest.php
@@ -2,10 +2,10 @@
 
 namespace SingleStore\Laravel\Tests\Hybrid\CreateTable;
 
+use PHPUnit\Framework\Attributes\Test;
 use SingleStore\Laravel\Schema\Blueprint;
 use SingleStore\Laravel\Tests\BaseTest;
 use SingleStore\Laravel\Tests\Hybrid\HybridTestHelpers;
-use PHPUnit\Framework\Attributes\Test;
 
 class UniqueKeysTest extends BaseTest
 {

--- a/tests/Hybrid/DropAllTablesTest.php
+++ b/tests/Hybrid/DropAllTablesTest.php
@@ -3,9 +3,9 @@
 namespace SingleStore\Laravel\Tests\Hybrid;
 
 use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
 use SingleStore\Laravel\Schema\Blueprint;
 use SingleStore\Laravel\Tests\BaseTest;
-use PHPUnit\Framework\Attributes\Test;
 
 class DropAllTablesTest extends BaseTest
 {

--- a/tests/Hybrid/DropAllTablesTest.php
+++ b/tests/Hybrid/DropAllTablesTest.php
@@ -5,12 +5,13 @@ namespace SingleStore\Laravel\Tests\Hybrid;
 use Illuminate\Support\Facades\Schema;
 use SingleStore\Laravel\Schema\Blueprint;
 use SingleStore\Laravel\Tests\BaseTest;
+use PHPUnit\Framework\Attributes\Test;
 
 class DropAllTablesTest extends BaseTest
 {
     use HybridTestHelpers;
 
-    /** @test */
+    #[Test]
     public function it_drops_all_tables_sequentially()
     {
         if (! $this->runHybridIntegrations()) {

--- a/tests/Hybrid/FulltextTest.php
+++ b/tests/Hybrid/FulltextTest.php
@@ -2,12 +2,11 @@
 
 namespace SingleStore\Laravel\Tests\Hybrid\Json;
 
-use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\Test;
 use SingleStore\Laravel\Schema\Blueprint;
 use SingleStore\Laravel\Tests\BaseTest;
 use SingleStore\Laravel\Tests\Hybrid\HybridTestHelpers;
-use PHPUnit\Framework\Attributes\Test;
 
 class FulltextTest extends BaseTest
 {

--- a/tests/Hybrid/FulltextTest.php
+++ b/tests/Hybrid/FulltextTest.php
@@ -7,21 +7,15 @@ use Illuminate\Support\Facades\DB;
 use SingleStore\Laravel\Schema\Blueprint;
 use SingleStore\Laravel\Tests\BaseTest;
 use SingleStore\Laravel\Tests\Hybrid\HybridTestHelpers;
+use PHPUnit\Framework\Attributes\Test;
 
 class FulltextTest extends BaseTest
 {
     use HybridTestHelpers;
 
-    /** @test */
+    #[Test]
     public function fulltext()
     {
-        if (version_compare(Application::VERSION, '8.79.0', '<=')) {
-            // fulltext not added until later on in laravel 8 releases
-            $this->markTestSkipped('requires higher laravel version');
-
-            return;
-        }
-
         $query = DB::table('test')->whereFullText('title', 'performance');
 
         $this->assertEquals(
@@ -61,16 +55,9 @@ class FulltextTest extends BaseTest
         );
     }
 
-    /** @test */
+    #[Test]
     public function fulltext_multicolumn()
     {
-        if (version_compare(Application::VERSION, '8.79.0', '<=')) {
-            // fulltext not added until later on in laravel 8 releases
-            $this->markTestSkipped('requires higher laravel version');
-
-            return;
-        }
-
         $query = DB::table('test')->whereFullText(['name', 'race'], 'Laika');
 
         $this->assertEquals(
@@ -106,16 +93,9 @@ class FulltextTest extends BaseTest
         $this->assertSame('Laika', $query->get()[0]->name);
     }
 
-    /** @test */
+    #[Test]
     public function throws_exception_when_using_an_unsupported_collation()
     {
-        if (version_compare(Application::VERSION, '8.79.0', '<=')) {
-            // fulltext not added until later on in laravel 8 releases
-            $this->markTestSkipped('requires higher laravel version');
-
-            return;
-        }
-
         if (! $this->runHybridIntegrations()) {
             return;
         }

--- a/tests/Hybrid/GroupLimitTest.php
+++ b/tests/Hybrid/GroupLimitTest.php
@@ -6,21 +6,15 @@ use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\DB;
 use SingleStore\Laravel\Schema\Blueprint;
 use SingleStore\Laravel\Tests\BaseTest;
+use PHPUnit\Framework\Attributes\Test;
 
 class GroupLimitTest extends BaseTest
 {
     use HybridTestHelpers;
 
-    /** @test */
+    #[Test]
     public function group_limit()
     {
-        if (version_compare(Application::VERSION, '11.0.0', '<')) {
-            // fulltext not added until later on in laravel 8 releases
-            $this->markTestSkipped('requires higher laravel version');
-
-            return;
-        }
-
         $query = DB::table('test')->orderBy('id')->groupLimit(2, 'group');
         $this->assertEquals(
             'select * from (select *, row_number() over (partition by `group` order by `id` asc) as `laravel_row` from `test`) as `laravel_table` where `laravel_row` <= 2 order by `laravel_row`',

--- a/tests/Hybrid/GroupLimitTest.php
+++ b/tests/Hybrid/GroupLimitTest.php
@@ -2,11 +2,10 @@
 
 namespace SingleStore\Laravel\Tests\Hybrid;
 
-use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\Test;
 use SingleStore\Laravel\Schema\Blueprint;
 use SingleStore\Laravel\Tests\BaseTest;
-use PHPUnit\Framework\Attributes\Test;
 
 class GroupLimitTest extends BaseTest
 {

--- a/tests/Hybrid/HybridTestHelpers.php
+++ b/tests/Hybrid/HybridTestHelpers.php
@@ -8,8 +8,8 @@ use Illuminate\Support\Facades\Schema;
 use Mockery;
 use SingleStore\Laravel\Connect\Connection;
 use SingleStore\Laravel\Schema\Blueprint;
-use SingleStore\Laravel\Schema\SingleStoreSchemaGrammar;
 use SingleStore\Laravel\Schema\SingleStoreSchemaBuilder;
+use SingleStore\Laravel\Schema\SingleStoreSchemaGrammar;
 
 trait HybridTestHelpers
 {

--- a/tests/Hybrid/Json/JsonContainsTest.php
+++ b/tests/Hybrid/Json/JsonContainsTest.php
@@ -3,6 +3,7 @@
 namespace SingleStore\Laravel\Tests\Hybrid\Json;
 
 use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\Test;
 use SingleStore\Laravel\Tests\BaseTest;
 use SingleStore\Laravel\Tests\Hybrid\HybridTestHelpers;
 
@@ -16,7 +17,7 @@ class JsonContainsTest extends BaseTest
     |--------------------------------------------------------------------------
     */
 
-    /** @test */
+    #[Test]
     public function json_contains_strings()
     {
         $query = DB::table('test')->whereJsonContains('data->array', 'en');
@@ -41,7 +42,7 @@ class JsonContainsTest extends BaseTest
         $this->assertEquals(1, $query->count());
     }
 
-    /** @test */
+    #[Test]
     public function json_contains_double()
     {
         $query = DB::table('test')->whereJsonContains('data->array', 1.5);
@@ -66,7 +67,7 @@ class JsonContainsTest extends BaseTest
         $this->assertEquals(1, $query->count());
     }
 
-    /** @test */
+    #[Test]
     public function json_contains_int()
     {
         $query = DB::table('test')->whereJsonContains('data->array', 1);
@@ -91,7 +92,7 @@ class JsonContainsTest extends BaseTest
         $this->assertEquals(1, $query->count());
     }
 
-    /** @test */
+    #[Test]
     public function json_contains_bool()
     {
         $query = DB::table('test')->whereJsonContains('data->array', true);
@@ -116,7 +117,7 @@ class JsonContainsTest extends BaseTest
         $this->assertEquals(1, $query->count());
     }
 
-    /** @test */
+    #[Test]
     public function json_contains_json()
     {
         $query = DB::table('test')->whereJsonContains('data->array', ['a' => 'b']);

--- a/tests/Hybrid/Json/JsonKeypathsTest.php
+++ b/tests/Hybrid/Json/JsonKeypathsTest.php
@@ -3,6 +3,7 @@
 namespace SingleStore\Laravel\Tests\Hybrid\Json;
 
 use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\Test;
 use SingleStore\Laravel\Tests\BaseTest;
 use SingleStore\Laravel\Tests\Hybrid\HybridTestHelpers;
 
@@ -10,7 +11,7 @@ class JsonKeypathsTest extends BaseTest
 {
     use HybridTestHelpers;
 
-    /** @test */
+    #[Test]
     public function it_compiles_column_only_without_path()
     {
         $query = DB::table('test')->where('data', '[]');
@@ -34,7 +35,7 @@ class JsonKeypathsTest extends BaseTest
         $this->assertEquals(1, $query->count());
     }
 
-    /** @test */
+    #[Test]
     public function it_compiles_nested_json_path()
     {
         $query = DB::table('test')->where('data->value1->value2->value3->value4', 2);
@@ -60,7 +61,7 @@ class JsonKeypathsTest extends BaseTest
         $this->assertEquals(1, $query->count());
     }
 
-    /** @test */
+    #[Test]
     public function it_compiles_nested_json_path_with_array_access()
     {
         $query = DB::table('test')->where('data->value1[0]->value2[2][0]', 1);

--- a/tests/Hybrid/Json/JsonUpdateTest.php
+++ b/tests/Hybrid/Json/JsonUpdateTest.php
@@ -2,7 +2,6 @@
 
 namespace SingleStore\Laravel\Tests\Hybrid\Json;
 
-use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\DB;
 use PHPUnit\Framework\Attributes\Test;
 use SingleStore\Laravel\Tests\BaseTest;

--- a/tests/Hybrid/Json/JsonUpdateTest.php
+++ b/tests/Hybrid/Json/JsonUpdateTest.php
@@ -4,6 +4,7 @@ namespace SingleStore\Laravel\Tests\Hybrid\Json;
 
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\Test;
 use SingleStore\Laravel\Tests\BaseTest;
 use SingleStore\Laravel\Tests\Hybrid\HybridTestHelpers;
 
@@ -11,7 +12,7 @@ class JsonUpdateTest extends BaseTest
 {
     use HybridTestHelpers;
 
-    /** @test */
+    #[Test]
     public function set_boolean_syntax()
     {
         [$logs] = DB::pretend(function ($database) {
@@ -26,7 +27,7 @@ class JsonUpdateTest extends BaseTest
         );
     }
 
-    /** @test */
+    #[Test]
     public function set_boolean_execution()
     {
         if (! $this->runHybridIntegrations()) {
@@ -47,7 +48,7 @@ class JsonUpdateTest extends BaseTest
         $this->assertEquals(1, DB::table('test')->where('data->value1', true)->count());
     }
 
-    /** @test */
+    #[Test]
     public function set_string_syntax()
     {
         if (! $this->runHybridIntegrations()) {
@@ -60,24 +61,15 @@ class JsonUpdateTest extends BaseTest
             ]);
         });
 
-        if (version_compare(Application::VERSION, '10.30.0', '>=')) {
-            // Laravel version >= 10.30.0
-            $this->assertEquals(
-                "update `test` set data = JSON_SET_JSON(data, 'value1', '\\\"foo\\\"')",
-                $logs['query']
-            );
-        } else {
-            // Laravel version < 10.30.0
-            $this->assertEquals(
-                "update `test` set data = JSON_SET_JSON(data, 'value1', ?)",
-                $logs['query']
-            );
-        }
+        $this->assertEquals(
+            "update `test` set data = JSON_SET_JSON(data, 'value1', '\\\"foo\\\"')",
+            $logs['query']
+        );
 
         $this->assertSame('"foo"', $logs['bindings'][0]);
     }
 
-    /** @test */
+    #[Test]
     public function set_string_execution()
     {
         if (! $this->runHybridIntegrations()) {
@@ -98,7 +90,7 @@ class JsonUpdateTest extends BaseTest
         $this->assertEquals(1, DB::table('test')->where('data->value1', 'bar')->count());
     }
 
-    /** @test */
+    #[Test]
     public function set_double_syntax()
     {
         [$logs] = DB::pretend(function ($database) {
@@ -107,24 +99,15 @@ class JsonUpdateTest extends BaseTest
             ]);
         });
 
-        if (version_compare(Application::VERSION, '10.30.0', '>=')) {
-            // Laravel version >= 10.30.0
-            $this->assertEquals(
-                "update `test` set data = JSON_SET_JSON(data, 'value1', 1.3)",
-                $logs['query']
-            );
-        } else {
-            // Laravel version < 10.30.0
-            $this->assertEquals(
-                "update `test` set data = JSON_SET_JSON(data, 'value1', ?)",
-                $logs['query']
-            );
-        }
+        $this->assertEquals(
+            "update `test` set data = JSON_SET_JSON(data, 'value1', 1.3)",
+            $logs['query']
+        );
 
         $this->assertSame(1.3, $logs['bindings'][0]);
     }
 
-    /** @test */
+    #[Test]
     public function set_double_execution()
     {
         if (! $this->runHybridIntegrations()) {
@@ -145,7 +128,7 @@ class JsonUpdateTest extends BaseTest
         $this->assertEquals(1, DB::table('test')->where('data->value1', 1.5)->count());
     }
 
-    /** @test */
+    #[Test]
     public function set_json_syntax()
     {
         if (! $this->runHybridIntegrations()) {
@@ -158,24 +141,15 @@ class JsonUpdateTest extends BaseTest
             ]);
         });
 
-        if (version_compare(Application::VERSION, '10.30.0', '>=')) {
-            // Laravel version >= 10.30.0
-            $this->assertEquals(
-                "update `test` set data = JSON_SET_JSON(data, 'value1', '{\\\"foo\\\":\\\"bar\\\"}')",
-                $logs['query']
-            );
-        } else {
-            // Laravel version < 10.30.0
-            $this->assertEquals(
-                "update `test` set data = JSON_SET_JSON(data, 'value1', ?)",
-                $logs['query']
-            );
-        }
+        $this->assertEquals(
+            "update `test` set data = JSON_SET_JSON(data, 'value1', '{\\\"foo\\\":\\\"bar\\\"}')",
+            $logs['query']
+        );
 
         $this->assertSame('{"foo":"bar"}', $logs['bindings'][0]);
     }
 
-    /** @test */
+    #[Test]
     public function set_json_execution()
     {
         if (! $this->runHybridIntegrations()) {

--- a/tests/Hybrid/Json/JsonWhereTest.php
+++ b/tests/Hybrid/Json/JsonWhereTest.php
@@ -3,6 +3,7 @@
 namespace SingleStore\Laravel\Tests\Hybrid\Json;
 
 use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\Test;
 use SingleStore\Laravel\Tests\BaseTest;
 use SingleStore\Laravel\Tests\Hybrid\HybridTestHelpers;
 
@@ -10,7 +11,7 @@ class JsonWhereTest extends BaseTest
 {
     use HybridTestHelpers;
 
-    /** @test */
+    #[Test]
     public function compile_unknown_as_string()
     {
         $query = DB::table('test')->where('data->value1->value2', 1);
@@ -23,7 +24,7 @@ class JsonWhereTest extends BaseTest
         $this->assertSame(1, $query->getBindings()[0]);
     }
 
-    /** @test */
+    #[Test]
     public function singlestore_will_cast_all_types()
     {
         $query1 = DB::table('test')->where('data->value1->value2', 'string');
@@ -55,7 +56,7 @@ class JsonWhereTest extends BaseTest
         $this->assertEquals(1, $query4->count());
     }
 
-    /** @test */
+    #[Test]
     public function json_boolean()
     {
         $query1 = DB::table('test')->where('data->value1->value2', true);
@@ -87,7 +88,7 @@ class JsonWhereTest extends BaseTest
         $this->assertEquals(1, $query1->count());
     }
 
-    /** @test */
+    #[Test]
     public function nested_where()
     {
         $query = DB::table('test')->where(function ($query) {
@@ -102,7 +103,7 @@ class JsonWhereTest extends BaseTest
         );
     }
 
-    /** @test */
+    #[Test]
     public function where_null()
     {
         $query = DB::table('test')->whereNull('data->value1')->orderBy('id');
@@ -128,7 +129,7 @@ class JsonWhereTest extends BaseTest
         $this->assertEquals($id3, $query->get()[1]->id);
     }
 
-    /** @test */
+    #[Test]
     public function where_null_raw()
     {
         $query = DB::table('test')->whereNull(DB::raw('(SELECT NULL)'))->orderBy('id');
@@ -155,7 +156,7 @@ class JsonWhereTest extends BaseTest
         $this->assertEquals($id4, $query->get()[3]->id);
     }
 
-    /** @test */
+    #[Test]
     public function where_not_null()
     {
         $query = DB::table('test')->whereNotNull('data->value1')->orderBy('id');
@@ -181,7 +182,7 @@ class JsonWhereTest extends BaseTest
         $this->assertEquals($id4, $query->get()[1]->id);
     }
 
-    /** @test */
+    #[Test]
     public function where_not_null_raw()
     {
         $query = DB::table('test')->whereNotNull(DB::raw('(SELECT 1)'))->orderBy('id');

--- a/tests/Hybrid/OptionTest.php
+++ b/tests/Hybrid/OptionTest.php
@@ -5,6 +5,7 @@ namespace SingleStore\Laravel\Tests\Hybrid;
 use Illuminate\Support\Facades\DB;
 use SingleStore\Laravel\Schema\Blueprint;
 use SingleStore\Laravel\Tests\BaseTest;
+use PHPUnit\Framework\Attributes\Test;
 
 class OptionTest extends BaseTest
 {
@@ -21,7 +22,7 @@ class OptionTest extends BaseTest
         }
     }
 
-    /** @test */
+    #[Test]
     public function single_option()
     {
         $query = DB::table('test')->options(['interpreter_mode' => 'compile']);
@@ -33,7 +34,7 @@ class OptionTest extends BaseTest
         }
     }
 
-    /** @test */
+    #[Test]
     public function empty_option()
     {
         $query = DB::table('test')->options([]);
@@ -45,7 +46,7 @@ class OptionTest extends BaseTest
         }
     }
 
-    /** @test */
+    #[Test]
     public function multi_option()
     {
         $query = DB::table('test')->options(['interpreter_mode' => 'compile', 'resource_pool' => 'default_pool']);

--- a/tests/Hybrid/OptionTest.php
+++ b/tests/Hybrid/OptionTest.php
@@ -3,9 +3,9 @@
 namespace SingleStore\Laravel\Tests\Hybrid;
 
 use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\Test;
 use SingleStore\Laravel\Schema\Blueprint;
 use SingleStore\Laravel\Tests\BaseTest;
-use PHPUnit\Framework\Attributes\Test;
 
 class OptionTest extends BaseTest
 {

--- a/tests/Hybrid/OrderByTest.php
+++ b/tests/Hybrid/OrderByTest.php
@@ -5,12 +5,13 @@ namespace SingleStore\Laravel\Tests\Hybrid;
 use Illuminate\Support\Facades\DB;
 use SingleStore\Laravel\Schema\Blueprint;
 use SingleStore\Laravel\Tests\BaseTest;
+use PHPUnit\Framework\Attributes\Test;
 
 class orderByTest extends BaseTest
 {
     use HybridTestHelpers;
 
-    /** @test */
+    #[Test]
     public function ignores_order_by_in_delete()
     {
         if (! $this->runHybridIntegrations()) {
@@ -28,7 +29,7 @@ class orderByTest extends BaseTest
         DB::table('test')->orderBy('id', 'asc')->delete();
     }
 
-    /** @test */
+    #[Test]
     public function ignores_order_by_in_update()
     {
         if (! $this->runHybridIntegrations()) {

--- a/tests/Hybrid/OrderByTest.php
+++ b/tests/Hybrid/OrderByTest.php
@@ -3,9 +3,9 @@
 namespace SingleStore\Laravel\Tests\Hybrid;
 
 use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\Test;
 use SingleStore\Laravel\Schema\Blueprint;
 use SingleStore\Laravel\Tests\BaseTest;
-use PHPUnit\Framework\Attributes\Test;
 
 class orderByTest extends BaseTest
 {

--- a/tests/Hybrid/OverridesGetConnection.php
+++ b/tests/Hybrid/OverridesGetConnection.php
@@ -2,24 +2,10 @@
 
 namespace SingleStore\Laravel\Tests\Hybrid;
 
-use Illuminate\Foundation\Application;
-
-if (version_compare(Application::VERSION, '9.0.0', '>=')) {
-    trait OverridesGetConnection
+trait OverridesGetConnection
+{
+    protected function getConnection($connection = null, $table = null)
     {
-        // Laravel 9
-        protected function getConnection($connection = null, $table = null)
-        {
-            return $this->getDatabaseConnection($connection, $table);
-        }
-    }
-} else {
-    trait OverridesGetConnection
-    {
-        // Laravel 8
-        protected function getConnection($connection = null)
-        {
-            return $this->getDatabaseConnection($connection);
-        }
+        return $this->getDatabaseConnection($connection, $table);
     }
 }

--- a/tests/Hybrid/RenameTest.php
+++ b/tests/Hybrid/RenameTest.php
@@ -3,10 +3,10 @@
 namespace SingleStore\Laravel\Tests\Hybrid;
 
 use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
 use SingleStore\Laravel\Schema\Blueprint;
 use SingleStore\Laravel\Schema\SingleStoreSchemaGrammar;
 use SingleStore\Laravel\Tests\BaseTest;
-use PHPUnit\Framework\Attributes\Test;
 
 class RenameTest extends BaseTest
 {
@@ -81,7 +81,7 @@ class RenameTest extends BaseTest
                 $table->renameColumn('data', 'data1');
             });
 
-            $columnNames = Schema::getColumnListing("test");
+            $columnNames = Schema::getColumnListing('test');
             $this->assertEquals(['id', 'data1'], $columnNames);
 
             $this->mockDatabaseConnection = $cached;

--- a/tests/Hybrid/RenameTest.php
+++ b/tests/Hybrid/RenameTest.php
@@ -81,8 +81,7 @@ class RenameTest extends BaseTest
                 $table->renameColumn('data', 'data1');
             });
 
-            $database = $this->getConnection()->getDatabaseName();
-            $columnNames = Schema::getColumnListing("$database.test");
+            $columnNames = Schema::getColumnListing("test");
             $this->assertEquals(['id', 'data1'], $columnNames);
 
             $this->mockDatabaseConnection = $cached;

--- a/tests/Hybrid/TransactionsTest.php
+++ b/tests/Hybrid/TransactionsTest.php
@@ -3,9 +3,9 @@
 namespace SingleStore\Laravel\Tests\Hybrid;
 
 use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\Test;
 use SingleStore\Laravel\Schema\Blueprint;
 use SingleStore\Laravel\Tests\BaseTest;
-use PHPUnit\Framework\Attributes\Test;
 
 class TransactionsTest extends BaseTest
 {

--- a/tests/Hybrid/TransactionsTest.php
+++ b/tests/Hybrid/TransactionsTest.php
@@ -5,6 +5,7 @@ namespace SingleStore\Laravel\Tests\Hybrid;
 use Illuminate\Support\Facades\DB;
 use SingleStore\Laravel\Schema\Blueprint;
 use SingleStore\Laravel\Tests\BaseTest;
+use PHPUnit\Framework\Attributes\Test;
 
 class TransactionsTest extends BaseTest
 {
@@ -21,7 +22,7 @@ class TransactionsTest extends BaseTest
         }
     }
 
-    /** @test */
+    #[Test]
     public function multiple_begin()
     {
         if (! $this->runHybridIntegrations()) {

--- a/tests/Hybrid/UnionTest.php
+++ b/tests/Hybrid/UnionTest.php
@@ -5,6 +5,7 @@ namespace SingleStore\Laravel\Tests\Hybrid;
 use Illuminate\Support\Facades\DB;
 use SingleStore\Laravel\Schema\Blueprint;
 use SingleStore\Laravel\Tests\BaseTest;
+use PHPUnit\Framework\Attributes\Test;
 
 class UnionTest extends BaseTest
 {
@@ -29,7 +30,7 @@ class UnionTest extends BaseTest
         }
     }
 
-    /** @test */
+    #[Test]
     public function union()
     {
         if (! $this->runHybridIntegrations()) {
@@ -48,7 +49,7 @@ class UnionTest extends BaseTest
         $this->assertEquals([1, 2, 100], $indexes);
     }
 
-    /** @test */
+    #[Test]
     public function union_all()
     {
         if (! $this->runHybridIntegrations()) {
@@ -67,7 +68,7 @@ class UnionTest extends BaseTest
         $this->assertEquals([1, 2, 3, 3, 4, 100], $indexes);
     }
 
-    /** @test */
+    #[Test]
     public function union_with_order_by_limit_and_offset()
     {
         if (! $this->runHybridIntegrations()) {
@@ -85,7 +86,7 @@ class UnionTest extends BaseTest
         $this->assertEquals([2], $indexes);
     }
 
-    /** @test */
+    #[Test]
     public function union_with_order_by()
     {
         if (! $this->runHybridIntegrations()) {
@@ -103,7 +104,7 @@ class UnionTest extends BaseTest
         $this->assertEquals([1, 2, 100], $indexes);
     }
 
-    /** @test */
+    #[Test]
     public function union_with_limit()
     {
         if (! $this->runHybridIntegrations()) {
@@ -117,7 +118,7 @@ class UnionTest extends BaseTest
         $this->assertCount(2, $res);
     }
 
-    /** @test */
+    #[Test]
     public function union_with_offset()
     {
         if (! $this->runHybridIntegrations()) {
@@ -131,7 +132,7 @@ class UnionTest extends BaseTest
         $this->assertCount(2, $res);
     }
 
-    /** @test */
+    #[Test]
     public function union_with_inner_offset()
     {
         if (! $this->runHybridIntegrations()) {

--- a/tests/Hybrid/UnionTest.php
+++ b/tests/Hybrid/UnionTest.php
@@ -3,9 +3,9 @@
 namespace SingleStore\Laravel\Tests\Hybrid;
 
 use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\Test;
 use SingleStore\Laravel\Schema\Blueprint;
 use SingleStore\Laravel\Tests\BaseTest;
-use PHPUnit\Framework\Attributes\Test;
 
 class UnionTest extends BaseTest
 {


### PR DESCRIPTION
Added support for Laravel 12.
Renamed classes to include the SingleStore prefix [#95].
Dropped support for older Laravel versions due to breaking changes introduced in Laravel 12.
These changes are not backward-compatible, so that this update will be released as v2.0.0.
For older Laravel versions, users can continue using the 1.5.x releases of the driver.
I plan to maintain the 1.5.x branch with bug fixes until older Laravel versions reach EOL.

Supersedes #98 . Original work by @ricardo-lobo , completed and updated for final merge.