### PR TITLE
Changed test to verify that transaction issue is resolved

### DIFF
--- a/tests/Hybrid/TransactionsTest.php
+++ b/tests/Hybrid/TransactionsTest.php
@@ -31,7 +31,6 @@ class TransactionsTest extends BaseTest
 
         DB::beginTransaction();
         DB::rollBack();
-        DB::insert('select 1');
         DB::beginTransaction();
         DB::rollBack();
     }


### PR DESCRIPTION
We had an issue with transaction handling #50 
It should be resolved in the newest S2 versions. This test used a workaround (running `DB::insert('select 1');`). 
Removing the workaround to verify that the issue is resolved.
` 