### PR TITLE
Added disk cleanup

### DIFF
--- a/.github/workflows/clean_disk_github_runner.sh
+++ b/.github/workflows/clean_disk_github_runner.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+echo "=== BEFORE ==="
+df -h
+
+sudo rm -rf /usr/share/dotnet
+sudo rm -rf /opt/ghc
+sudo rm -rf /usr/local/share/boost
+sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+sudo rm -rf /usr/local/lib/android
+sudo rm -rf /opt/hostedtoolcache/CodeQL
+sudo rm -rf /opt/hostedtoolcache/Ruby
+sudo rm -rf /opt/hostedtoolcache/Go
+
+sudo rm -rf /opt/hostedtoolcache/Java*
+sudo rm -rf /opt/hostedtoolcache/Python*
+sudo rm -rf /opt/hostedtoolcache/Node*
+sudo rm -rf /opt/hostedtoolcache/PyPy*
+sudo rm -rf /opt/hostedtoolcache/Swift*
+sudo rm -rf /opt/hostedtoolcache/gradle*
+sudo rm -rf /opt/hostedtoolcache/maven*
+sudo rm -rf /opt/hostedtoolcache/Rust*
+sudo rm -rf /opt/hostedtoolcache/Perl*
+sudo rm -rf /opt/hostedtoolcache/llvm
+
+sudo rm -rf /usr/local/lib/node_modules || true
+sudo rm -rf /usr/local/share/powershell || true
+sudo rm -rf /usr/local/julia* || true
+sudo rm -rf /usr/share/swift || true
+
+sudo rm -rf /var/lib/apt/lists/* || true
+sudo rm -rf /var/cache/apt/* || true
+sudo rm -rf /var/cache/man/* || true
+sudo rm -rf /var/log/* || true
+sudo rm -rf /tmp/* || true
+
+sudo apt-get update || true
+sudo apt-get purge -y \
+    azure-cli \
+    google-cloud-cli \
+    google-chrome-stable \
+    firefox \
+    powershell \
+    mono-devel \
+    hhvm \
+    php* \
+    dotnet-sdk-* \
+    temurin-* \
+    openjdk-* \
+    mysql-client* \
+    postgresql-client* \
+    || true
+
+sudo apt-get autoremove -y || true
+sudo apt-get clean || true
+
+docker system prune -af || true
+docker volume prune -f || true
+
+echo "=== AFTER ==="
+df -h

--- a/.github/workflows/clean_disk_github_runner.sh
+++ b/.github/workflows/clean_disk_github_runner.sh
@@ -44,12 +44,12 @@ sudo apt-get purge -y \
     powershell \
     mono-devel \
     hhvm \
-    php* \
-    dotnet-sdk-* \
-    temurin-* \
-    openjdk-* \
-    mysql-client* \
-    postgresql-client* \
+    '^php' \
+    '^dotnet-sdk-' \
+    '^temurin-' \
+    '^openjdk-' \
+    '^mysql-client' \
+    '^postgresql-client' \
     || true
 
 sudo apt-get autoremove -y || true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,6 +41,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      - name: Clean Disk Space
+        run: |
+          ./.github/workflows/clean_disk_github_runner.sh
+
       - name: Cache dependencies
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
Previously, I observed failures connected to a lack of disk space.
This PR uses a script from https://gist.github.com/pmishchenko-ua/58a54011e2908dd8529d8fa5659cecee to remove redundant stuff.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because CI now deletes large preinstalled toolchains and prunes Docker, which could break workflows if any later step implicitly relies on those tools or cached images.
> 
> **Overview**
> Adds a `clean_disk_github_runner.sh` script and runs it early in the `tests.yml` GitHub Actions job to reclaim disk space on `ubuntu-22.04` runners.
> 
> The cleanup aggressively removes preinstalled SDK/tool caches (e.g., .NET/Java/Python/Node/Go), purges several apt packages, clears apt/log/tmp caches, and prunes Docker images/volumes, with before/after `df -h` output for visibility.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ace8175aa207f53a5c799a3b6a0285c04fff0594. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->