### PR TITLE
chore: improve release process and version handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,6 @@ permissions:
 jobs:
   tests:
     uses: ./.github/workflows/tests.yml
-    permissions:
-      contents: read
-      actions: write
 
   release:
     needs: tests
@@ -24,6 +21,6 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  tests:
+    uses: ./.github/workflows/tests.yml
+
+  release:
+    needs: tests
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,9 @@ permissions:
 jobs:
   tests:
     uses: ./.github/workflows/tests.yml
+    permissions:
+      contents: read
+      actions: write
 
   release:
     needs: tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,7 @@
 name: tests
 
 on:
+  workflow_call:
   push:
     branches:
       - main

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-22.04
-    if: "!contains(github.event.head_commit.message, 'ci skip')"
+    if: github.event_name == 'workflow_call' || !contains(github.event.head_commit.message, 'ci skip')
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-22.04
-    if: github.event_name == 'workflow_call' || !contains(github.event.head_commit.message, 'ci skip')
+    if: startsWith(github.ref, 'refs/tags/') || !contains(github.event.head_commit.message, 'ci skip')
     strategy:
       fail-fast: false
       matrix:

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ This repository contains the official SingleStoreDB Driver for Laravel. This dri
   - [Increment Columns without Primary Key](#increment-columns-without-primary-key)
   - [Full-text search using FULLTEXT indexes](#full-text-search-using-fulltext-indexes)
 - [Testing](#testing)
+- [Release Process](#release-process)
 - [License](#license)
 - [Resources](#resources)
 - [User agreement](#user-agreement)
@@ -469,6 +470,29 @@ Now when executing your tests, enable the integration tests by running
 ```shell
 HYBRID_INTEGRATION=1 ./vendor/bin/phpunit
 ```
+
+## Release process
+
+Releases are fully automated. The only step required is to push a version tag.
+Use semantic versioning with a `v` prefix:
+
+```
+v<major>.<minor>.<patch>
+```
+
+Examples: `v2.0.0`, `v2.0.3`
+
+```bash
+git tag v2.0.3
+git push origin v2.0.3
+```
+
+Pushing a tag triggers the [Release workflow](.github/workflows/release.yml), which:
+
+1. Runs the test suite
+2. Creates a [GitHub Release](https://github.com/singlestore-labs/singlestoredb-laravel-driver/releases) with auto-generated release notes
+
+[Packagist](https://packagist.org/packages/singlestoredb/singlestoredb-laravel) auto-updates from GitHub tags, so the new version will be available there shortly after the tag is pushed.
 
 ## Compatibility matrix 
 <table>


### PR DESCRIPTION
 - Added a release workflow that runs tests and creates a GitHub release on tag push
 - Added a release section to the README

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to GitHub Actions and documentation; no runtime or package code is modified.
> 
> **Overview**
> Adds **tag-driven releases**: pushing a `v*` tag runs the existing test matrix via a new `release` workflow, then publishes a GitHub Release with auto-generated notes (`softprops/action-gh-release`).
> 
> Refactors **`tests.yml`** so it can be invoked with `workflow_call` from `release.yml`, and relaxes the test job `if` so tag pushes always run tests even when commit messages contain `ci skip`.
> 
> Documents the flow in the **README** (semver `v` tags, workflow steps, Packagist picking up tags).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c8b4647c5d2cc6e6e4ae7dab7411b6bc5ebb574. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->